### PR TITLE
Added All Tall, All Small and All or Nothing at All bets

### DIFF
--- a/Python/run_simulations.py
+++ b/Python/run_simulations.py
@@ -19,6 +19,7 @@ def run_printout(n_roll, n_shooter, bankroll, strategy, strategy_name, runout):
         table.run(n_roll, n_shooter, verbose=True)
     sys.stdout = sys.__stdout__ # reset stdout
 
+
 def run_simulation(n_sim, n_roll, bankroll, strategy, strategy_name, runout):
     runout_str = "_runout" if runout else ""
     # Run simulation of n_roll rolls (estimated rolls/hour with 5 players) 1000 times

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -587,7 +587,7 @@ class AllTall(AllBet):
         self.name = 'AllTall'
         self.bet_amount = bet_amount
         self.numbers = [8, 9, 10, 11, 12]
-        self.payoutratio = 34
+        self.payoutratio = 30
 
 
 class AllSmall(AllBet):
@@ -596,7 +596,7 @@ class AllSmall(AllBet):
         self.name = 'AllSmall'
         self.bet_amount = bet_amount
         self.numbers = [2, 3, 4, 5, 6]
-        self.payoutratio = 34
+        self.payoutratio = 30
 
 
 class AllOrNothingAtAll(AllBet):
@@ -605,4 +605,4 @@ class AllOrNothingAtAll(AllBet):
         self.name = 'AllOrNothingAtAll'
         self.bet_amount = bet_amount
         self.numbers = [2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
-        self.payoutratio = 175
+        self.payoutratio = 150

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -558,9 +558,10 @@ class AllBet(Bet):
         self.numbers = []
         self.rolled_numbers: list[int] = []
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float]:
+    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0.0
+        remove = False
 
         if dice_object.total in self.numbers and dice_object.total not in self.rolled_numbers:
             self.rolled_numbers.append(dice_object.total)
@@ -569,10 +570,15 @@ class AllBet(Bet):
         if self.numbers == self.rolled_numbers:
             status = 'win'
             win_amount = self.bet_amount * self.payoutratio
+            remove = True
         elif dice_object.total == 7:
             status = 'lose'
+            remove = True
 
-        return status, win_amount
+        return status, win_amount, remove
+
+    def allowed(self, table: 'Table') -> bool:
+        return table.new_shooter
 
 
 class AllTall(AllBet):

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -550,3 +550,53 @@ class Fire(Bet):
 
     def allowed(self, table: 'Table') -> bool:
         return table.new_shooter
+
+
+class AllBet(Bet):
+    def __init__(self, bet_amount: float):
+        super().__init__(bet_amount)
+        self.numbers = []
+        self.rolled_numbers: list[int] = []
+
+    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float]:
+        status: str | None = None
+        win_amount: float = 0.0
+
+        if dice_object.total in self.numbers and dice_object.total not in self.rolled_numbers:
+            self.rolled_numbers.append(dice_object.total)
+            self.rolled_numbers.sort()
+
+        if self.numbers == self.rolled_numbers:
+            status = 'win'
+            win_amount = self.bet_amount * self.payoutratio
+        elif dice_object.total == 7:
+            status = 'lose'
+
+        return status, win_amount
+
+
+class AllTall(AllBet):
+    def __init__(self, bet_amount):
+        super().__init__(bet_amount)
+        self.name = 'AllTall'
+        self.bet_amount = bet_amount
+        self.numbers = [8, 9, 10, 11, 12]
+        self.payoutratio = 34
+
+
+class AllSmall(AllBet):
+    def __init__(self, bet_amount):
+        super().__init__(bet_amount)
+        self.name = 'AllSmall'
+        self.bet_amount = bet_amount
+        self.numbers = [2, 3, 4, 5, 6]
+        self.payoutratio = 34
+
+
+class AllOrNothingAtAll(AllBet):
+    def __init__(self, bet_amount):
+        super().__init__(bet_amount=bet_amount)
+        self.name = 'AllOrNothingAtAll'
+        self.bet_amount = bet_amount
+        self.numbers = [2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
+        self.payoutratio = 175

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from crapssim import Player
 from crapssim.bet import Fire, Bet, PassLine, Come, Odds, DontPass, DontCome, Field
+
+from crapssim.bet import AllSmall, AllTall, AllOrNothingAtAll
 from crapssim.dice import Dice
 from crapssim.table import Table, Point
 
@@ -108,3 +110,58 @@ def test_bet_allowed_new_shooter(bet, new_shooter, allowed):
         table.fixed_roll((3, 4))
 
     assert bet.allowed(table) == allowed
+
+
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
+    ([(2, 2)], None, 0.0),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 34),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+])
+def test_all_small(rolls: list[tuple[int]], correct_status: str | None, correct_win_amount: float):
+    table = Table()
+    dice = Dice()
+    bet = AllSmall(1)
+
+    status, win_amt = None, None
+    for roll in rolls:
+        dice.fixed_roll(roll)
+        status, win_amt = bet._update_bet(table, dice)
+    assert (status, win_amt) == (correct_status, correct_win_amount)
+
+
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
+    ([(2, 2)], None, 0.0),
+    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6)], 'win', 34),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+])
+def test_all_tall(rolls: list[tuple[int]], correct_status: str | None, correct_win_amount: float):
+    table = Table()
+    dice = Dice()
+    bet = AllTall(1)
+
+    status, win_amt = None, None
+    for roll in rolls:
+        dice.fixed_roll(roll)
+        status, win_amt = bet._update_bet(table, dice)
+    assert (status, win_amt) == (correct_status, correct_win_amount)
+
+
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
+    ([(2, 2)], None, 0.0),
+    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6),
+      (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 175),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+])
+def test_all_or_nothing_at_all(rolls: list[tuple[int]],
+                               correct_status: str | None,
+                               correct_win_amount: float):
+    table = Table()
+    dice = Dice()
+    bet = AllOrNothingAtAll(1)
+
+    status, win_amt = None, None
+    for roll in rolls:
+        dice.fixed_roll(roll)
+        status, win_amt = bet._update_bet(table, dice)
+    assert (status, win_amt) == (correct_status, correct_win_amount)
+

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -114,7 +114,7 @@ def test_bet_allowed_new_shooter(bet, new_shooter, allowed):
 
 @pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
     ([(2, 2)], None, 0.0, False),
-    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 34, True),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 30, True),
     ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
 def test_all_small(rolls: list[tuple[int]],
@@ -134,7 +134,7 @@ def test_all_small(rolls: list[tuple[int]],
 
 @pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
     ([(2, 2)], None, 0.0, False),
-    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6)], 'win', 34, True),
+    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6)], 'win', 30, True),
     ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
 def test_all_tall(rolls: list[tuple[int]],
@@ -155,7 +155,7 @@ def test_all_tall(rolls: list[tuple[int]],
 @pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
     ([(2, 2)], None, 0.0, False),
     ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6),
-      (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 175, True),
+      (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 150, True),
     ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
 def test_all_or_nothing_at_all(rolls: list[tuple[int]],

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -112,56 +112,63 @@ def test_bet_allowed_new_shooter(bet, new_shooter, allowed):
     assert bet.allowed(table) == allowed
 
 
-@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
-    ([(2, 2)], None, 0.0),
-    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 34),
-    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
+    ([(2, 2)], None, 0.0, False),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 34, True),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
-def test_all_small(rolls: list[tuple[int]], correct_status: str | None, correct_win_amount: float):
+def test_all_small(rolls: list[tuple[int]],
+                   correct_status: str | None,
+                   correct_win_amount: float,
+                   correct_remove: bool):
     table = Table()
     dice = Dice()
     bet = AllSmall(1)
 
-    status, win_amt = None, None
+    status, win_amt, remove = None, None, None
     for roll in rolls:
         dice.fixed_roll(roll)
-        status, win_amt = bet._update_bet(table, dice)
-    assert (status, win_amt) == (correct_status, correct_win_amount)
+        status, win_amt, remove = bet._update_bet(table, dice)
+    assert (status, win_amt, remove) == (correct_status, correct_win_amount, correct_remove)
 
 
-@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
-    ([(2, 2)], None, 0.0),
-    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6)], 'win', 34),
-    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
+    ([(2, 2)], None, 0.0, False),
+    ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6)], 'win', 34, True),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
-def test_all_tall(rolls: list[tuple[int]], correct_status: str | None, correct_win_amount: float):
+def test_all_tall(rolls: list[tuple[int]],
+                  correct_status: str | None,
+                  correct_win_amount: float,
+                  correct_remove: bool):
     table = Table()
     dice = Dice()
     bet = AllTall(1)
 
-    status, win_amt = None, None
+    status, win_amt, remove = None, None, None
     for roll in rolls:
         dice.fixed_roll(roll)
-        status, win_amt = bet._update_bet(table, dice)
-    assert (status, win_amt) == (correct_status, correct_win_amount)
+        status, win_amt, remove = bet._update_bet(table, dice)
+    assert (status, win_amt, remove) == (correct_status, correct_win_amount, correct_remove)
 
 
-@pytest.mark.parametrize('rolls, correct_status, correct_win_amount', [
-    ([(2, 2)], None, 0.0),
+@pytest.mark.parametrize('rolls, correct_status, correct_win_amount, correct_remove', [
+    ([(2, 2)], None, 0.0, False),
     ([(10, 1), (10, 2), (7, 2), (5, 5), (2, 6),
-      (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 175),
-    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0)
+      (1, 1), (1, 2), (2, 2), (2, 3), (3, 3)], 'win', 175, True),
+    ([(1, 1), (1, 2), (2, 2), (2, 3), (3, 4)], 'lose', 0.0, True)
 ])
 def test_all_or_nothing_at_all(rolls: list[tuple[int]],
                                correct_status: str | None,
-                               correct_win_amount: float):
+                               correct_win_amount: float,
+                               correct_remove: bool):
     table = Table()
     dice = Dice()
     bet = AllOrNothingAtAll(1)
 
-    status, win_amt = None, None
+    status, win_amt, remove = None, None, None
     for roll in rolls:
         dice.fixed_roll(roll)
-        status, win_amt = bet._update_bet(table, dice)
-    assert (status, win_amt) == (correct_status, correct_win_amount)
+        status, win_amt, remove = bet._update_bet(table, dice)
+    assert (status, win_amt, remove) == (correct_status, correct_win_amount, correct_remove)
 


### PR DESCRIPTION
I added 3 new bets, AllTall, AllSmall, and AllOrNothingAtAll. We don't have these bets locally and I haven't played them myself, but I saw that they are very popular in Vegas from the [Reddit/Twitter Craps Minimums spreadsheet](https://docs.google.com/spreadsheets/d/1txvaruxsoprcfgHOXkNh4MSqwxz3GYIciX_8TNOigGk/edit#gid=0). I took most of the information regarding how these bets work and the rules for them from [here](https://www.little-creek.com/casino/bonus-craps.php#:~:text=More%20Wagering%2C%20More%20Winning&text=Played%20just%20like%20a%20regular,a%20whopping%20175%20to%201.).

For anyone more familiar with this bet, do the odds listed change from the ones listed (34 and 175) or are those pretty consistent across tables? If not, we should probably add a way to edit the payouts for those, perhaps utilizing the table.payouts dict. Also, are there any requirements for when the bet is place (ex. requiring a new shooter or that the point is on/off)? 

If neither of those are required these have tests and should be ready to go.   