### PR TITLE
Improve Table Payouts per issue #13

### DIFF
--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -447,15 +447,18 @@ class CAndE(Bet):
 
         if self.table.dice.total in self.winning_numbers:
             status = "win"
-            if self.table.dice.total in [2, 3, 12]:
-                payout_ratio = 3
-            elif self.table.dice.total in [11]:
-                payout_ratio = 7
-            win_amount = payout_ratio * self.bet_amount
+            win_amount = self.payout_ratio * self.bet_amount
         elif self.table.dice.total in self.losing_numbers:
             status = "lose"
 
         return status, win_amount, remove
+
+    @property
+    def payout_ratio(self):
+        if self.table.dice.total in [2, 3, 12]:
+            return 3
+        elif self.table.dice.total in [11]:
+            return 7
 
 
 class Hardway(Bet):

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -28,7 +28,7 @@ class Bet(ABC):
         Numbers to roll for this bet to win
     losing_numbers : list
         Numbers to roll that cause this bet to lose
-    payoutratio : float
+    payout_ratio : float
         Ratio that bet pays out on a win
     removable : bool
         Whether the bet can be removed or not
@@ -40,7 +40,7 @@ class Bet(ABC):
         self.subname: str = str()
         self.winning_numbers: list[int] = []
         self.losing_numbers: list[int] = []
-        self.payoutratio: float = float(1)
+        self.payout_ratio: float = float(1)
         self.removable: bool = True
 
     def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
@@ -66,7 +66,7 @@ class Bet(ABC):
         if dice_object.total in self.winning_numbers:
             status = "win"
             remove = True
-            win_amount = self.payoutratio * self.bet_amount
+            win_amount = self.payout_ratio * self.bet_amount
         elif dice_object.total in self.losing_numbers:
             status = "lose"
             remove = True
@@ -101,7 +101,7 @@ class PassLine(Bet):
         self.name: str = "PassLine"
         self.winning_numbers: list[int] = [7, 11]
         self.losing_numbers: list[int] = [2, 3, 12]
-        self.payoutratio: float = 1.0
+        self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
     def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
@@ -112,7 +112,7 @@ class PassLine(Bet):
         if dice_object.total in self.winning_numbers:
             status = "win"
             remove = True
-            win_amount = self.payoutratio * self.bet_amount
+            win_amount = self.payout_ratio * self.bet_amount
         elif dice_object.total in self.losing_numbers:
             status = "lose"
             remove = True
@@ -166,11 +166,11 @@ class Odds(Bet):
         self.losing_numbers: list[int] = bet_object.losing_numbers
 
         if self.winning_numbers == [4] or self.winning_numbers == [10]:
-            self.payoutratio = 2 / 1
+            self.payout_ratio = 2 / 1
         elif self.winning_numbers == [5] or self.winning_numbers == [9]:
-            self.payoutratio = 3 / 2
+            self.payout_ratio = 3 / 2
         elif self.winning_numbers == [6] or self.winning_numbers == [8]:
-            self.payoutratio = 6 / 5
+            self.payout_ratio = 6 / 5
 
     def allowed(self, table: 'Table') -> bool:
         if isinstance(self.bet_object, PassLine):
@@ -199,7 +199,7 @@ class Place4(Place):
         self.name: str = "Place4"
         self.winning_numbers: list[int] = [4]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 9 / 5
+        self.payout_ratio: float = 9 / 5
 
 
 class Place5(Place):
@@ -208,7 +208,7 @@ class Place5(Place):
         self.name: str = "Place5"
         self.winning_numbers: list[int] = [5]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 7 / 5
+        self.payout_ratio: float = 7 / 5
 
 
 class Place6(Place):
@@ -217,7 +217,7 @@ class Place6(Place):
         self.name: str = "Place6"
         self.winning_numbers: list[int] = [6]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 7 / 6
+        self.payout_ratio: float = 7 / 6
 
 
 class Place8(Place):
@@ -226,7 +226,7 @@ class Place8(Place):
         self.name: str = "Place8"
         self.winning_numbers: list[int] = [8]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 7 / 6
+        self.payout_ratio: float = 7 / 6
 
 
 class Place9(Place):
@@ -235,7 +235,7 @@ class Place9(Place):
         self.name: str = "Place9"
         self.winning_numbers: list[int] = [9]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 7 / 5
+        self.payout_ratio: float = 7 / 5
 
 
 class Place10(Place):
@@ -244,7 +244,7 @@ class Place10(Place):
         self.name: str = "Place10"
         self.winning_numbers: list[int] = [10]
         self.losing_numbers: list[int] = [7]
-        self.payoutratio: float = 9 / 5
+        self.payout_ratio: float = 9 / 5
 
 
 """
@@ -302,7 +302,7 @@ class DontPass(Bet):
         self.winning_numbers: list[int] = [2, 3]
         self.losing_numbers: list[int] = [7, 11]
         self.push_numbers: list[int] = [12]
-        self.payoutratio: float = 1.0
+        self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
     def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
@@ -313,7 +313,7 @@ class DontPass(Bet):
         if dice_object.total in self.winning_numbers:
             status = "win"
             remove = True
-            win_amount = self.payoutratio * self.bet_amount
+            win_amount = self.payout_ratio * self.bet_amount
         elif dice_object.total in self.losing_numbers:
             status = "lose"
             remove = True
@@ -364,11 +364,11 @@ class LayOdds(Bet):
         self.losing_numbers: list[int] = bet_object.losing_numbers
 
         if self.losing_numbers == [4] or self.losing_numbers == [10]:
-            self.payoutratio = 1 / 2
+            self.payout_ratio = 1 / 2
         elif self.losing_numbers == [5] or self.losing_numbers == [9]:
-            self.payoutratio = 2 / 3
+            self.payout_ratio = 2 / 3
         elif self.losing_numbers == [6] or self.losing_numbers == [8]:
-            self.payoutratio = 5 / 6
+            self.payout_ratio = 5 / 6
 
 
 """
@@ -382,7 +382,7 @@ class Any7(Bet):
         self.name: str = "Any7"
         self.winning_numbers: list[int] = [7]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
-        self.payoutratio: int = 4
+        self.payout_ratio: int = 4
 
 
 class Two(Bet):
@@ -391,7 +391,7 @@ class Two(Bet):
         self.name: str = "Two"
         self.winning_numbers: list[int] = [2]
         self.losing_numbers: list[int] = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        self.payoutratio: int = 30
+        self.payout_ratio: int = 30
 
 
 class Three(Bet):
@@ -400,7 +400,7 @@ class Three(Bet):
         self.name: str = "Three"
         self.winning_numbers: list[int] = [3]
         self.losing_numbers: list[int] = [2, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        self.payoutratio: int = 15
+        self.payout_ratio: int = 15
 
 
 class Yo(Bet):
@@ -409,7 +409,7 @@ class Yo(Bet):
         self.name: str = "Yo"
         self.winning_numbers: list[int] = [11]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 12]
-        self.payoutratio: int = 15
+        self.payout_ratio: int = 15
 
 
 class Boxcars(Bet):
@@ -418,7 +418,7 @@ class Boxcars(Bet):
         self.name: str = "Boxcars"
         self.winning_numbers: list[int] = [12]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-        self.payoutratio: int = 30
+        self.payout_ratio: int = 30
 
 
 class AnyCraps(Bet):
@@ -427,7 +427,7 @@ class AnyCraps(Bet):
         self.name: str = "AnyCraps"
         self.winning_numbers: list[int] = [2, 3, 12]
         self.losing_numbers: list[int] = [4, 5, 6, 7, 8, 9, 10, 11]
-        self.payoutratio: int = 7
+        self.payout_ratio: int = 7
 
 
 class CAndE(Bet):
@@ -445,10 +445,10 @@ class CAndE(Bet):
         if dice_object.total in self.winning_numbers:
             status = "win"
             if dice_object.total in [2, 3, 12]:
-                payoutratio = 3
+                payout_ratio = 3
             elif dice_object.total in [11]:
-                payoutratio = 7
-            win_amount = payoutratio * self.bet_amount
+                payout_ratio = 7
+            win_amount = payout_ratio * self.bet_amount
         elif dice_object.total in self.losing_numbers:
             status = "lose"
 
@@ -478,7 +478,7 @@ class Hardway(Bet):
         if dice_object.result == self.winning_result:
             status = "win"
             remove = True
-            win_amount = self.payoutratio * self.bet_amount
+            win_amount = self.payout_ratio * self.bet_amount
         elif dice_object.total in [self.number, 7]:
             status = "lose"
             remove = True
@@ -492,7 +492,7 @@ class Hard4(Hardway):
         self.name: str = "Hard4"
         self.winning_result: list[int | None] = [2, 2]
         self.number: int = 4
-        self.payoutratio: int = 7
+        self.payout_ratio: int = 7
 
 
 class Hard6(Hardway):
@@ -501,7 +501,7 @@ class Hard6(Hardway):
         self.name: str = "Hard6"
         self.winning_result: list[int | None] = [3, 3]
         self.number: int = 6
-        self.payoutratio: int = 9
+        self.payout_ratio: int = 9
 
 
 class Hard8(Hardway):
@@ -510,7 +510,7 @@ class Hard8(Hardway):
         self.name: str = "Hard8"
         self.winning_result: list[int | None] = [4, 4]
         self.number: int = 8
-        self.payoutratio: int = 9
+        self.payout_ratio: int = 9
 
 
 class Hard10(Hardway):
@@ -519,7 +519,7 @@ class Hard10(Hardway):
         self.name: str = "Hard10"
         self.winning_result: list[int | None] = [5, 5]
         self.number: int = 10
-        self.payoutratio: int = 7
+        self.payout_ratio: int = 7
 
 
 class Fire(Bet):

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -280,21 +280,22 @@ class Field(Bet):
         self.winning_numbers: list[int] = [2, 3, 4, 9, 10, 11, 12]
         self.losing_numbers: list[int] = [5, 6, 7, 8]
 
+    @property
+    def payout_ratio(self):
+        if self.table.dice.total in self.double_winning_numbers:
+            return 2
+        if self.table.dice.total in self.triple_winning_numbers:
+            return 3
+        return 1
+
     def _update_bet(self) -> tuple[str | None, float, bool]:
-        status: str | None = None
-        win_amount: float = 0
+        win_amount: float = 0.0
         remove: bool = True
 
-        if self.table.dice.total in self.triple_winning_numbers:
+        if self.table.dice.total in self.winning_numbers:
             status = "win"
-            win_amount = 3 * self.bet_amount
-        elif self.table.dice.total in self.double_winning_numbers:
-            status = "win"
-            win_amount = 2 * self.bet_amount
-        elif self.table.dice.total in self.winning_numbers:
-            status = "win"
-            win_amount = 1 * self.bet_amount
-        elif self.table.dice.total in self.losing_numbers:
+            win_amount = self.payout_ratio * self.bet_amount
+        else:
             status = "lose"
 
         return status, win_amount, remove
@@ -561,11 +562,11 @@ class Fire(Bet):
             if self.current_point not in self.points_made:
                 self.points_made = list(set(self.points_made + [self.table.dice.total]))
                 if len(self.points_made) == 4:
-                    status, win_amount, remove = 'win', 24 * self.bet_amount, False
+                    status, win_amount, remove = 'win', self.payout_ratio, False
                 elif len(self.points_made) == 5:
-                    status, win_amount, remove = 'win', 249 * self.bet_amount, False
+                    status, win_amount, remove = 'win', self.payout_ratio, False
                 elif len(self.points_made) == 6:
-                    status, win_amount, remove = 'win', 999 * self.bet_amount, True
+                    status, win_amount, remove = 'win', self.payout_ratio, True
             self.current_point = None
         elif self.current_point is not None and self.table.dice.total == 7:
             status, win_amount, remove = 'lose', 0.0, True
@@ -573,3 +574,12 @@ class Fire(Bet):
 
     def allowed(self, table: 'Table') -> bool:
         return table.new_shooter
+
+    @property
+    def payout_ratio(self):
+        if len(self.points_made) == 4:
+            return 24
+        elif len(self.points_made) == 5:
+            return 249
+        elif len(self.points_made) == 6:
+            return 999

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -39,10 +39,13 @@ class Bet(ABC):
         self.subname: str = str()
         self.winning_numbers: list[int] = []
         self.losing_numbers: list[int] = []
-        self.payout_ratio: float = float(1)
         self.removable: bool = True
         self.player: Player | None = player
         self.table: Table | None = table
+
+    @property
+    def payout_ratio(self):
+        return 1.0
 
     def _update_bet(self) -> tuple[str | None, float, bool]:
         """
@@ -93,12 +96,13 @@ Passline and Come bets
 
 
 class PassLine(Bet):
+    payout_ratio: float = 1.0
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "PassLine"
         self.winning_numbers: list[int] = [7, 11]
         self.losing_numbers: list[int] = [2, 3, 12]
-        self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
     def _update_bet(self) -> tuple[str | None, float, bool]:
@@ -162,12 +166,14 @@ class Odds(Bet):
         self.winning_numbers: list[int] = bet_object.winning_numbers
         self.losing_numbers: list[int] = bet_object.losing_numbers
 
+    @property
+    def payout_ratio(self):
         if self.winning_numbers == [4] or self.winning_numbers == [10]:
-            self.payout_ratio = 2 / 1
+            return 2 / 1
         elif self.winning_numbers == [5] or self.winning_numbers == [9]:
-            self.payout_ratio = 3 / 2
+            return 3 / 2
         elif self.winning_numbers == [6] or self.winning_numbers == [8]:
-            self.payout_ratio = 6 / 5
+            return 6 / 5
 
     def allowed(self, table: 'Table') -> bool:
         if isinstance(self.bet_object, PassLine):
@@ -175,6 +181,7 @@ class Odds(Bet):
                 return False
             else:
                 return True
+
 
 """
 Place Bets on 4,5,6,8,9,10
@@ -191,57 +198,63 @@ class Place(Bet):
 
 
 class Place4(Place):
+    payout_ratio: float = 9 / 5
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place4"
         self.winning_numbers: list[int] = [4]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 9 / 5
 
 
 class Place5(Place):
+    payout_ratio: float = 7 / 5
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place5"
         self.winning_numbers: list[int] = [5]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 7 / 5
 
 
 class Place6(Place):
+    payout_ratio: float = 7 / 6
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place6"
         self.winning_numbers: list[int] = [6]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 7 / 6
 
 
 class Place8(Place):
+    payout_ratio: float = 7 / 6
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place8"
         self.winning_numbers: list[int] = [8]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 7 / 6
 
 
 class Place9(Place):
+    payout_ratio: float = 7 / 5
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place9"
         self.winning_numbers: list[int] = [9]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 7 / 5
 
 
 class Place10(Place):
+    payout_ratio: float = 9 / 5
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Place10"
         self.winning_numbers: list[int] = [10]
         self.losing_numbers: list[int] = [7]
-        self.payout_ratio: float = 9 / 5
 
 
 """
@@ -293,13 +306,14 @@ Don't pass and Don't come bets
 
 
 class DontPass(Bet):
+    payout_ratio: float = 1.0
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "DontPass"
         self.winning_numbers: list[int] = [2, 3]
         self.losing_numbers: list[int] = [7, 11]
         self.push_numbers: list[int] = [12]
-        self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
     def _update_bet(self) -> tuple[str | None, float, bool]:
@@ -360,12 +374,14 @@ class LayOdds(Bet):
         self.winning_numbers: list[int] = bet_object.winning_numbers
         self.losing_numbers: list[int] = bet_object.losing_numbers
 
+    @property
+    def payout_ratio(self):
         if self.losing_numbers == [4] or self.losing_numbers == [10]:
-            self.payout_ratio = 1 / 2
+            return 1 / 2
         elif self.losing_numbers == [5] or self.losing_numbers == [9]:
-            self.payout_ratio = 2 / 3
+            return 2 / 3
         elif self.losing_numbers == [6] or self.losing_numbers == [8]:
-            self.payout_ratio = 5 / 6
+            return 5 / 6
 
 
 """
@@ -374,57 +390,63 @@ Center-table Bets
 
 
 class Any7(Bet):
+    payout_ratio: int = 4
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Any7"
         self.winning_numbers: list[int] = [7]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
-        self.payout_ratio: int = 4
 
 
 class Two(Bet):
+    payout_ratio: int = 30
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Two"
         self.winning_numbers: list[int] = [2]
         self.losing_numbers: list[int] = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        self.payout_ratio: int = 30
 
 
 class Three(Bet):
+    payout_ratio: int = 15
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Three"
         self.winning_numbers: list[int] = [3]
         self.losing_numbers: list[int] = [2, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        self.payout_ratio: int = 15
 
 
 class Yo(Bet):
+    payout_ratio: int = 15
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Yo"
         self.winning_numbers: list[int] = [11]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 12]
-        self.payout_ratio: int = 15
 
 
 class Boxcars(Bet):
+    payout_ratio: int = 30
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Boxcars"
         self.winning_numbers: list[int] = [12]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-        self.payout_ratio: int = 30
 
 
 class AnyCraps(Bet):
+    payout_ratio: int = 7
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "AnyCraps"
         self.winning_numbers: list[int] = [2, 3, 12]
         self.losing_numbers: list[int] = [4, 5, 6, 7, 8, 9, 10, 11]
-        self.payout_ratio: int = 7
 
 
 class CAndE(Bet):
@@ -484,39 +506,43 @@ class Hardway(Bet):
 
 
 class Hard4(Hardway):
+    payout_ratio: int = 7
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount)
         self.name: str = "Hard4"
         self.winning_result: list[int | None] = [2, 2]
         self.number: int = 4
-        self.payout_ratio: int = 7
 
 
 class Hard6(Hardway):
+    payout_ratio: int = 9
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount)
         self.name: str = "Hard6"
         self.winning_result: list[int | None] = [3, 3]
         self.number: int = 6
-        self.payout_ratio: int = 9
 
 
 class Hard8(Hardway):
+    payout_ratio: int = 9
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount)
         self.name: str = "Hard8"
         self.winning_result: list[int | None] = [4, 4]
         self.number: int = 8
-        self.payout_ratio: int = 9
 
 
 class Hard10(Hardway):
+    payout_ratio: int = 7
+
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount)
         self.name: str = "Hard10"
         self.winning_result: list[int | None] = [5, 5]
         self.number: int = 10
-        self.payout_ratio: int = 7
 
 
 class Fire(Bet):

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -1,10 +1,9 @@
 import typing
 from abc import ABC
 
-from crapssim.dice import Dice
-
 if typing.TYPE_CHECKING:
     from crapssim.table import Table
+    from crapssim.player import Player
 
 
 class Bet(ABC):
@@ -34,7 +33,7 @@ class Bet(ABC):
         Whether the bet can be removed or not
     """
 
-    def __init__(self, bet_amount: typing.SupportsFloat):
+    def __init__(self, bet_amount: typing.SupportsFloat, player, table=None):
         self.bet_amount: float = float(bet_amount)
         self.name: str = str()
         self.subname: str = str()
@@ -42,17 +41,15 @@ class Bet(ABC):
         self.losing_numbers: list[int] = []
         self.payout_ratio: float = float(1)
         self.removable: bool = True
+        self.player: Player | None = player
+        self.table: Table | None = table
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         """
         Returns whether the bets status is win, lose or None and if win the amount won.
 
         Parameters
         ----------
-        table_object : Table
-            The table to check the bet was made on.
-        dice_object : Dice
-            The dice to check the bet against.
 
         Returns
         -------
@@ -63,11 +60,11 @@ class Bet(ABC):
         win_amount: float = 0.0
         remove = False
 
-        if dice_object.total in self.winning_numbers:
+        if self.table.dice.total in self.winning_numbers:
             status = "win"
             remove = True
             win_amount = self.payout_ratio * self.bet_amount
-        elif dice_object.total in self.losing_numbers:
+        elif self.table.dice.total in self.losing_numbers:
             status = "lose"
             remove = True
 
@@ -97,27 +94,27 @@ Passline and Come bets
 
 class PassLine(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "PassLine"
         self.winning_numbers: list[int] = [7, 11]
         self.losing_numbers: list[int] = [2, 3, 12]
         self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0.0
         remove: bool = False
 
-        if dice_object.total in self.winning_numbers:
+        if self.table.dice.total in self.winning_numbers:
             status = "win"
             remove = True
             win_amount = self.payout_ratio * self.bet_amount
-        elif dice_object.total in self.losing_numbers:
+        elif self.table.dice.total in self.losing_numbers:
             status = "lose"
             remove = True
         elif self.prepoint:
-            self.winning_numbers = [dice_object.total]
+            self.winning_numbers = [self.table.dice.total]
             self.losing_numbers = [7]
             self.prepoint = False
             self.removable = False
@@ -135,8 +132,8 @@ class Come(PassLine):
         super().__init__(bet_amount)
         self.name: str = "Come"
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
-        status, win_amount, remove = super()._update_bet(table_object, dice_object)
+    def _update_bet(self) -> tuple[str | None, float, bool]:
+        status, win_amount, remove = super()._update_bet()
         if not self.prepoint and self.subname == "":
             self.subname = "".join(str(e) for e in self.winning_numbers)
         return status, win_amount, remove
@@ -154,7 +151,7 @@ Passline/Come bet odds
 
 class Odds(Bet):
     def __init__(self, bet_amount: typing.SupportsFloat, bet_object: Bet):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.bet_object = bet_object
 
         if not isinstance(bet_object, PassLine) and not isinstance(bet_object, Come):
@@ -185,17 +182,17 @@ Place Bets on 4,5,6,8,9,10
 
 
 class Place(Bet):
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         # place bets are inactive when point is "Off"
-        if table_object.point == "On":
-            return super()._update_bet(table_object, dice_object)
+        if self.table.point == "On":
+            return super()._update_bet()
         else:
             return None, 0, False
 
 
 class Place4(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place4"
         self.winning_numbers: list[int] = [4]
         self.losing_numbers: list[int] = [7]
@@ -204,7 +201,7 @@ class Place4(Place):
 
 class Place5(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place5"
         self.winning_numbers: list[int] = [5]
         self.losing_numbers: list[int] = [7]
@@ -213,7 +210,7 @@ class Place5(Place):
 
 class Place6(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place6"
         self.winning_numbers: list[int] = [6]
         self.losing_numbers: list[int] = [7]
@@ -222,7 +219,7 @@ class Place6(Place):
 
 class Place8(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place8"
         self.winning_numbers: list[int] = [8]
         self.losing_numbers: list[int] = [7]
@@ -231,7 +228,7 @@ class Place8(Place):
 
 class Place9(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place9"
         self.winning_numbers: list[int] = [9]
         self.losing_numbers: list[int] = [7]
@@ -240,7 +237,7 @@ class Place9(Place):
 
 class Place10(Place):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Place10"
         self.winning_numbers: list[int] = [10]
         self.losing_numbers: list[int] = [7]
@@ -263,28 +260,28 @@ class Field(Bet):
     """
 
     def __init__(self, bet_amount: float, double: list[int] = [2, 12], triple: list[int] = []):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Field"
         self.double_winning_numbers: list[int] = double
         self.triple_winning_numbers: list[int] = triple
         self.winning_numbers: list[int] = [2, 3, 4, 9, 10, 11, 12]
         self.losing_numbers: list[int] = [5, 6, 7, 8]
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0
         remove: bool = True
 
-        if dice_object.total in self.triple_winning_numbers:
+        if self.table.dice.total in self.triple_winning_numbers:
             status = "win"
             win_amount = 3 * self.bet_amount
-        elif dice_object.total in self.double_winning_numbers:
+        elif self.table.dice.total in self.double_winning_numbers:
             status = "win"
             win_amount = 2 * self.bet_amount
-        elif dice_object.total in self.winning_numbers:
+        elif self.table.dice.total in self.winning_numbers:
             status = "win"
             win_amount = 1 * self.bet_amount
-        elif dice_object.total in self.losing_numbers:
+        elif self.table.dice.total in self.losing_numbers:
             status = "lose"
 
         return status, win_amount, remove
@@ -297,7 +294,7 @@ Don't pass and Don't come bets
 
 class DontPass(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "DontPass"
         self.winning_numbers: list[int] = [2, 3]
         self.losing_numbers: list[int] = [7, 11]
@@ -305,23 +302,23 @@ class DontPass(Bet):
         self.payout_ratio: float = 1.0
         self.prepoint: bool = True
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0.0
         remove: bool = False
 
-        if dice_object.total in self.winning_numbers:
+        if self.table.dice.total in self.winning_numbers:
             status = "win"
             remove = True
             win_amount = self.payout_ratio * self.bet_amount
-        elif dice_object.total in self.losing_numbers:
+        elif self.table.dice.total in self.losing_numbers:
             status = "lose"
             remove = True
-        elif dice_object.total in self.push_numbers:
+        elif self.table.dice.total in self.push_numbers:
             remove = True
         elif self.prepoint:
             self.winning_numbers = [7]
-            self.losing_numbers = [dice_object.total]
+            self.losing_numbers = [self.table.dice.total]
             self.push_numbers = []
             self.prepoint = False
 
@@ -338,8 +335,8 @@ class DontCome(DontPass):
         super().__init__(bet_amount)
         self.name: str = "DontCome"
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
-        status, win_amount, remove = super()._update_bet(table_object, dice_object)
+    def _update_bet(self) -> tuple[str | None, float, bool]:
+        status, win_amount, remove = super()._update_bet()
         if not self.prepoint and self.subname == "":
             self.subname = "".join(str(e) for e in self.losing_numbers)
         return status, win_amount, remove
@@ -357,7 +354,7 @@ Don't pass/Don't come lay odds
 
 class LayOdds(Bet):
     def __init__(self, bet_amount: float, bet_object: Bet):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "LayOdds"
         self.subname: str = "".join(str(e) for e in bet_object.losing_numbers)
         self.winning_numbers: list[int] = bet_object.winning_numbers
@@ -378,7 +375,7 @@ Center-table Bets
 
 class Any7(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Any7"
         self.winning_numbers: list[int] = [7]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
@@ -387,7 +384,7 @@ class Any7(Bet):
 
 class Two(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Two"
         self.winning_numbers: list[int] = [2]
         self.losing_numbers: list[int] = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -396,7 +393,7 @@ class Two(Bet):
 
 class Three(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Three"
         self.winning_numbers: list[int] = [3]
         self.losing_numbers: list[int] = [2, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -405,7 +402,7 @@ class Three(Bet):
 
 class Yo(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Yo"
         self.winning_numbers: list[int] = [11]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 12]
@@ -414,7 +411,7 @@ class Yo(Bet):
 
 class Boxcars(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Boxcars"
         self.winning_numbers: list[int] = [12]
         self.losing_numbers: list[int] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -423,7 +420,7 @@ class Boxcars(Bet):
 
 class AnyCraps(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "AnyCraps"
         self.winning_numbers: list[int] = [2, 3, 12]
         self.losing_numbers: list[int] = [4, 5, 6, 7, 8, 9, 10, 11]
@@ -432,24 +429,24 @@ class AnyCraps(Bet):
 
 class CAndE(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "CAndE"
         self.winning_numbers: list[int] = [2, 3, 11, 12]
         self.losing_numbers: list[int] = [4, 5, 6, 7, 8, 9, 10]
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0
         remove: bool = True
 
-        if dice_object.total in self.winning_numbers:
+        if self.table.dice.total in self.winning_numbers:
             status = "win"
-            if dice_object.total in [2, 3, 12]:
+            if self.table.dice.total in [2, 3, 12]:
                 payout_ratio = 3
-            elif dice_object.total in [11]:
+            elif self.table.dice.total in [11]:
                 payout_ratio = 7
             win_amount = payout_ratio * self.bet_amount
-        elif dice_object.total in self.losing_numbers:
+        elif self.table.dice.total in self.losing_numbers:
             status = "lose"
 
         return status, win_amount, remove
@@ -466,20 +463,20 @@ class Hardway(Bet):
     """
 
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.number: int | None = None
         self.winning_result: list[int | None] = [None, None]
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status: str | None = None
         win_amount: float = 0.0
         remove: bool = False
 
-        if dice_object.result == self.winning_result:
+        if self.table.dice.result == self.winning_result:
             status = "win"
             remove = True
             win_amount = self.payout_ratio * self.bet_amount
-        elif dice_object.total in [self.number, 7]:
+        elif self.table.dice.total in [self.number, 7]:
             status = "lose"
             remove = True
 
@@ -524,19 +521,19 @@ class Hard10(Hardway):
 
 class Fire(Bet):
     def __init__(self, bet_amount: float):
-        super().__init__(bet_amount)
+        super().__init__(bet_amount, None)
         self.name: str = "Fire"
         self.bet_amount: float = bet_amount
         self.points_made: list[int] = []
         self.current_point: int | None = None
 
-    def _update_bet(self, table_object: "Table", dice_object: Dice) -> tuple[str | None, float, bool]:
+    def _update_bet(self) -> tuple[str | None, float, bool]:
         status, win_amount, remove = None, 0.0, False
-        if self.current_point is None and dice_object.total in (4, 5, 6, 8, 9, 10):
-            self.current_point = dice_object.total
-        elif self.current_point is not None and self.current_point == dice_object.total:
+        if self.current_point is None and self.table.dice.total in (4, 5, 6, 8, 9, 10):
+            self.current_point = self.table.dice.total
+        elif self.current_point is not None and self.current_point == self.table.dice.total:
             if self.current_point not in self.points_made:
-                self.points_made = list(set(self.points_made + [dice_object.total]))
+                self.points_made = list(set(self.points_made + [self.table.dice.total]))
                 if len(self.points_made) == 4:
                     status, win_amount, remove = 'win', 24 * self.bet_amount, False
                 elif len(self.points_made) == 5:
@@ -544,7 +541,7 @@ class Fire(Bet):
                 elif len(self.points_made) == 6:
                     status, win_amount, remove = 'win', 999 * self.bet_amount, True
             self.current_point = None
-        elif self.current_point is not None and dice_object.total == 7:
+        elif self.current_point is not None and self.table.dice.total == 7:
             status, win_amount, remove = 'lose', 0.0, True
         return status, win_amount, remove
 

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -272,21 +272,15 @@ class Field(Bet):
         Set of numbers that pay triple on the field bet (default = [])
     """
 
-    def __init__(self, bet_amount: float, double: list[int] = [2, 12], triple: list[int] = []):
+    def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Field"
-        self.double_winning_numbers: list[int] = double
-        self.triple_winning_numbers: list[int] = triple
         self.winning_numbers: list[int] = [2, 3, 4, 9, 10, 11, 12]
         self.losing_numbers: list[int] = [5, 6, 7, 8]
 
     @property
     def payout_ratio(self):
-        if self.table.dice.total in self.double_winning_numbers:
-            return 2
-        if self.table.dice.total in self.triple_winning_numbers:
-            return 3
-        return 1
+        return self.table.payouts['field_ratios'][self.table.dice.total]
 
     def _update_bet(self) -> tuple[str | None, float, bool]:
         win_amount: float = 0.0
@@ -577,9 +571,5 @@ class Fire(Bet):
 
     @property
     def payout_ratio(self):
-        if len(self.points_made) == 4:
-            return 24
-        elif len(self.points_made) == 5:
-            return 249
-        elif len(self.points_made) == 6:
-            return 999
+        if len(self.points_made) in self.table.payouts['fire_points']:
+            return self.table.payouts['fire_points'][len(self.points_made)]

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -33,7 +33,7 @@ class Bet(ABC):
         Whether the bet can be removed or not
     """
 
-    def __init__(self, bet_amount: typing.SupportsFloat, player, table=None):
+    def __init__(self, bet_amount: typing.SupportsFloat, player=None, table=None):
         self.bet_amount: float = float(bet_amount)
         self.name: str = str()
         self.subname: str = str()

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -27,8 +27,6 @@ class Bet(ABC):
         Numbers to roll for this bet to win
     losing_numbers : list
         Numbers to roll that cause this bet to lose
-    payout_ratio : float
-        Ratio that bet pays out on a win
     removable : bool
         Whether the bet can be removed or not
     """
@@ -263,15 +261,6 @@ Field bet
 
 
 class Field(Bet):
-    """
-    Parameters
-    ----------
-    double : list
-        Set of numbers that pay double on the field bet (default = [2,12])
-    triple : list
-        Set of numbers that pay triple on the field bet (default = [])
-    """
-
     def __init__(self, bet_amount: float):
         super().__init__(bet_amount, None)
         self.name: str = "Field"

--- a/crapssim/player.py
+++ b/crapssim/player.py
@@ -71,6 +71,8 @@ class Player:
                 existing_bet: Bet = self.get_bet(bet_object.name, bet_object.subname)
                 existing_bet.bet_amount += bet_object.bet_amount
             else:
+                bet_object.player = self
+                bet_object.table = self.table
                 self.bets_on_table.append(bet_object)
 
             self.total_bet_amount += bet_object.bet_amount
@@ -115,7 +117,7 @@ class Player:
             dict[str, dict[str, str | None | float]]:
         info = {}
         for b in self.bets_on_table[:]:
-            status, win_amount, remove = b._update_bet(self.table, self.table.dice)
+            status, win_amount, remove = b._update_bet()
 
             if status == "win":
                 self.bankroll += win_amount + b.bet_amount

--- a/crapssim/strategy.py
+++ b/crapssim/strategy.py
@@ -385,11 +385,7 @@ def ironcross(player: 'Player', table: 'Table', mult: int | str = 1) -> None:
 
     if table.point == "On":
         if not player.has_bet("Field"):
-            player.bet(Field(
-                player.unit,
-                double=table.payouts["fielddouble"],
-                triple=table.payouts["fieldtriple"],
-            ))
+            player.bet(Field(player.unit))
 
 
 def hammerlock(player: 'Player', table: 'Table', mode: str | None = None) -> dict[str, str]:
@@ -478,11 +474,11 @@ def risk12(player: 'Player', table: 'Table', winnings: typing.SupportsFloat = 0)
     if table.pass_rolls == 0:
         winnings = 0
 
-    if table.point == "Off":
-        if table.last_roll in table.payouts["fielddouble"]:
+    if table.point == "Off" and table.last_roll in table.payouts["field_ratios"]:
+        if table.payouts["field_ratios"][table.last_roll] == 2:
             # win double from the field, lose pass line, for a net of 1 unit win
             winnings += player.unit
-        elif table.last_roll in table.payouts["fieldtriple"]:
+        elif table.payouts["field_ratios"][table.last_roll] == 3:
             # win triple from the field, lose pass line, for a net of 2 unit win
             winnings += 2 * player.unit
         elif table.last_roll == 11:
@@ -490,11 +486,7 @@ def risk12(player: 'Player', table: 'Table', winnings: typing.SupportsFloat = 0)
             winnings += 2 * player.unit
 
     if table.point == "Off":
-        player.bet(Field(
-            player.unit,
-            double=table.payouts["fielddouble"],
-            triple=table.payouts["fieldtriple"],
-        ))
+        player.bet(Field(player.unit))
         if table.last_roll == 7:
             for bet_nm in ["Place6", "Place8"]:
                 player.remove_if_present(bet_nm)
@@ -561,11 +553,7 @@ def dicedoctor(player: 'Player', table: 'Table', progression: int = 0) -> dict[s
     else:
         amount = bet_progression[len(bet_progression) - 1] * player.unit / 5
 
-    player.bet(Field(
-        amount,
-        double=table.payouts["fielddouble"],
-        triple=table.payouts["fieldtriple"],
-    ))
+    player.bet(Field(amount))
 
     progression += 1
 

--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -41,7 +41,8 @@ class Table(object):
         self.point: Point = Point()
         self.dice: Dice = Dice()
         self.bet_update_info: dict | None = None
-        self.payouts: dict[str, list[int]] = {"fielddouble": [2, 12], "fieldtriple": []}
+        self.payouts: dict[str, typing.Any] = {'field_ratios': {2: 2, 3: 1, 4: 1, 9: 1, 10: 1, 11: 1, 12: 2},
+                                               'fire_points': {4: 24, 5: 249, 6: 999}}
         self.pass_rolls: int = 0
         self.last_roll: int | None = None
         self.n_shooters: int = 1
@@ -129,7 +130,6 @@ class Table(object):
 
         continue_rolling = True
         while continue_rolling:
-
             self.add_player_bets(verbose=verbose)
             self.roll_and_update(verbose)
 

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -31,15 +31,17 @@ from crapssim.table import Table, Point
     (crapssim.bet.Hard10(1), -0.0278),
 ])
 def test_ev_oneroll(bet, ev):
-    d = Dice()
     t = Table()
+    p = Player(100)
+    p.sit_at_table(t)
     t.point.status = "On"  # for place bets to pay properly
-
     outcomes = []
+    bet.player = p
+    bet.table = t
     for d1 in range(1, 7):
         for d2 in range(1, 7):
-            d.fixed_roll([d1, d2])
-            status, win_amt, remove = bet._update_bet(t, d)
+            t.dice.fixed_roll([d1, d2])
+            status, win_amt, remove = bet._update_bet()
 
             outcomes.append(win_amt if status == "win" else -1 if status == "lose" else 0)
 
@@ -59,13 +61,15 @@ def test_ev_oneroll(bet, ev):
 ])
 def test_fire(rolls, correct_status, correct_win_amt, correct_remove):
     table = Table()
-    dice = Dice()
+    player = Player(100)
     bet = Fire(1)
+    bet.player = player
+    bet.table = table
 
     status, win_amt, remove = None, None, None
     for roll in rolls:
-        dice.fixed_roll(roll)
-        status, win_amt, remove = bet._update_bet(table, dice)
+        table.dice.fixed_roll(roll)
+        status, win_amt, remove = bet._update_bet()
 
     assert (status, win_amt, remove) == (correct_status, correct_win_amt, correct_remove)
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -18,7 +18,7 @@ def test_irremovable_bet():
     table = Table()
     dice = Dice()
     dice.fixed_roll([2, 2])
-    player.get_bet('PassLine')._update_bet(table, dice)
+    player.get_bet('PassLine')._update_bet()
     player.remove_if_present('PassLine')
     assert len(player.bets_on_table) == 1
 


### PR DESCRIPTION
See Issue #13 for discussion. 

This changes Table.payouts to store all bet information that varies by table on the Table (ex. Field Payouts, Fire Bet Point payouts, etc.) It also makes table an attribute of Bet in order to access those variables when doing the update logic. It also makes Bet.payout_ratio a property of bet instead of an attribute so for bets where the payout ratio varies based on table settings or other logic than a static number.  