### PR TITLE
Add BetAll, BetTall, BetSmall strategies

### DIFF
--- a/crapssim/strategy/single_bet.py
+++ b/crapssim/strategy/single_bet.py
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from crapssim.bet import (
+    All,
     Any7,
     Bet,
     Boxcars,
@@ -17,6 +18,8 @@ from crapssim.bet import (
     Hop,
     PassLine,
     Place,
+    Small,
+    Tall,
     Three,
     Two,
     Yo,
@@ -315,3 +318,18 @@ class BetBoxcars(_BaseSingleBet):
 class BetFire(_BaseSingleBet):
     def __init__(self, bet_amount: float, mode=StrategyMode.ADD_IF_NOT_BET):
         super().__init__(Fire(bet_amount), mode=mode)
+
+
+class BetAll(_BaseSingleBet):
+    def __init__(self, bet_amount: float, mode=StrategyMode.ADD_IF_NOT_BET):
+        super().__init__(All(bet_amount), mode=mode)
+
+
+class BetTall(_BaseSingleBet):
+    def __init__(self, bet_amount: float, mode=StrategyMode.ADD_IF_NOT_BET):
+        super().__init__(Tall(bet_amount), mode=mode)
+
+
+class BetSmall(_BaseSingleBet):
+    def __init__(self, bet_amount: float, mode=StrategyMode.ADD_IF_NOT_BET):
+        super().__init__(Small(bet_amount), mode=mode)

--- a/docs/tutorial-strategy-01.ipynb
+++ b/docs/tutorial-strategy-01.ipynb
@@ -73,7 +73,10 @@
     "| `BetThree()`    | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
     "| `BetYo()`       | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
     "| `BetBoxcars()`  | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
-    "| `BetFire()`     | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |"
+    "| `BetFire()`     | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
+    "| `BetAll()`      | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
+    "| `BetTall()`     | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |\n",
+    "| `BetSmall()`    | crapssim.strategy.single_bet | ADD_IF_NON_EXISTENT |                                                |"
    ]
   },
   {

--- a/tests/integration/test_strategy_single_bet.py
+++ b/tests/integration/test_strategy_single_bet.py
@@ -2,6 +2,7 @@ import pytest
 
 from crapssim import Table
 from crapssim.bet import (
+    All,
     Any7,
     Bet,
     Boxcars,
@@ -15,16 +16,21 @@ from crapssim.bet import (
     Odds,
     PassLine,
     Place,
+    Small,
+    Tall,
     Three,
     Two,
     Yo,
 )
 from crapssim.strategy.single_bet import (
+    BetAll,
     BetAny7,
     BetBoxcars,
     BetFire,
     BetHardWay,
     BetHop,
+    BetSmall,
+    BetTall,
     BetThree,
     BetTwo,
     BetYo,
@@ -49,6 +55,9 @@ from crapssim.table import TableUpdate
         (BetYo(bet_amount=5), [], [Yo(amount=5.0)]),
         (BetBoxcars(bet_amount=5), [], [Boxcars(amount=5.0)]),
         (BetFire(bet_amount=5), [], [Fire(amount=5.0)]),
+        (BetAll(bet_amount=5), [], [All(amount=5.0)]),
+        (BetTall(bet_amount=5), [], [Tall(amount=5.0)]),
+        (BetSmall(bet_amount=5), [], [Small(amount=5.0)]),
     ],
 )
 def test_strategies_compare_bets(

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1299,6 +1299,18 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
             crapssim.strategy.single_bet.BetFire(1),
             "BetFire(bet_amount=1.0, mode=StrategyMode.ADD_IF_NOT_BET)",
         ),
+        (
+            crapssim.strategy.single_bet.BetAll(1),
+            "BetAll(bet_amount=1.0, mode=StrategyMode.ADD_IF_NOT_BET)",
+        ),
+        (
+            crapssim.strategy.single_bet.BetTall(1),
+            "BetTall(bet_amount=1.0, mode=StrategyMode.ADD_IF_NOT_BET)",
+        ),
+        (
+            crapssim.strategy.single_bet.BetSmall(1),
+            "BetSmall(bet_amount=1.0, mode=StrategyMode.ADD_IF_NOT_BET)",
+        ),
         # Example strategies
         (crapssim.strategy.examples.Pass2Come(1), "Pass2Come(amount=1.0)"),
         (


### PR DESCRIPTION
These strategies were previously missing when single bet strategies were put together

* Add `BetAll`, `BetTall`, and `BetSmall` strategies
* Update representative testing
* Add to "Tutorial 01" in documentation