### PR TITLE
Restrict strategy updates during runout

### DIFF
--- a/tests/integration/test_table.py
+++ b/tests/integration/test_table.py
@@ -1,10 +1,11 @@
 import os
+from unittest.mock import MagicMock, call
 
 import pytest
 
 from crapssim import Table
 from crapssim.strategy.odds import PassLineOddsMultiplier
-from crapssim.strategy.single_bet import BetPassLine, BetPlace
+from crapssim.strategy.single_bet import BetCome, BetPassLine, BetPlace
 
 
 def test_table_print_output(capsys):
@@ -27,3 +28,37 @@ def test_table_print_output(capsys):
         output_content = f.read().strip()
 
     assert captured.out.rstrip() == output_content
+
+
+@pytest.mark.parametrize(
+    "strategy", [BetPassLine(10) + BetCome(10), BetPlace({6: 12, 9: 10})]
+)
+def test_table_runout_comebets(strategy):
+    table = Table(seed=9)
+    table.add_player(bankroll=200, strategy=strategy)
+
+    # Get some bets active
+    table.run(max_rolls=4, runout=False)
+    table.players[0].strategy.update_bets = MagicMock()
+    # Only run strategy once
+    table.run(max_rolls=1, runout=True)
+
+    n_strategy_updates = table.players[0].strategy.update_bets.call_count
+    assert (
+        n_strategy_updates == 1
+    ), "The strategy called `update_bets` more than one with 1 additional roll"
+    assert table.dice.n_rolls > 5
+
+
+@pytest.mark.parametrize(
+    "strategy", [BetPassLine(10) + BetCome(10), BetPlace({6: 12, 9: 10})]
+)
+def test_table_without_runout_comebets(strategy):
+    table = Table(seed=9)
+    table.add_player(bankroll=200, strategy=strategy)
+
+    table.run(max_rolls=5, runout=False)
+
+    assert (
+        table.dice.n_rolls == 5
+    ), "Run stopped later than max_rolls even though runout=False"


### PR DESCRIPTION
* Add run_complete concept to Table object
* Restrict TableUpdate from running strategies if run_complete, continue other table updates
* Add tests to cover this for future
* Fixes #60