### PR TITLE
Verbose: include roll and shooter counts

### DIFF
--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -74,7 +74,7 @@ class TableUpdate:
             table.dice.roll()
         if verbose:
             print("")
-            print("Dice out!")
+            print(f"Dice out! (roll {table.dice.n_rolls}, shooter {table.n_shooters})")
             print(f"Shooter rolled {table.dice.total} {table.dice.result}")
 
     @staticmethod

--- a/tests/integration/verified_table_output.txt
+++ b/tests/integration/verified_table_output.txt
@@ -6,46 +6,46 @@ Player 1: Strategy=BetPlace(place_bet_amounts={5: 10, 6: 12, 8: 12, 4: 10}, mode
 Player 0: Bankroll=95.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=1000.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 1, shooter 1)
 Shooter rolled 7 (5, 2)
 Player 0 won $5.0 on PassLine(amount=5.0)!
 Point is Off (None)
 Player 0: Bankroll=100.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=1000.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 2, shooter 1)
 Shooter rolled 8 (2, 6)
 Point is On (8)
 Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=968.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 3, shooter 1)
 Shooter rolled 4 (2, 2)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
 Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 4, shooter 1)
 Shooter rolled 9 (4, 5)
 Point is On (8)
 Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 5, shooter 1)
 Shooter rolled 10 (4, 6)
 Point is On (8)
 Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 6, shooter 1)
 Shooter rolled 4 (1, 3)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
 Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=1004.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 7, shooter 1)
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
 Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0).
@@ -56,19 +56,19 @@ Point is Off (None)
 Player 0: Bankroll=85.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=1004.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 8, shooter 2)
 Shooter rolled 6 (3, 3)
 Point is On (6)
 Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 9, shooter 2)
 Shooter rolled 2 (1, 1)
 Point is On (6)
 Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 10, shooter 2)
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
 Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0).
@@ -79,13 +79,13 @@ Point is Off (None)
 Player 0: Bankroll=70.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 11, shooter 3)
 Shooter rolled 8 (6, 2)
 Point is On (8)
 Player 0: Bankroll=60.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=940.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 12, shooter 3)
 Shooter rolled 8 (6, 2)
 Player 0 won $5.0 on PassLine(amount=5.0)!
 Player 0 won $12.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)!
@@ -93,39 +93,39 @@ Point is Off (None)
 Player 0: Bankroll=87.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 13, shooter 3)
 Shooter rolled 3 (1, 2)
 Player 0 lost $5.0 on PassLine(amount=5.0).
 Point is Off (None)
 Player 0: Bankroll=82.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 14, shooter 3)
 Shooter rolled 5 (3, 2)
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 15, shooter 3)
 Shooter rolled 11 (6, 5)
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
-Dice out!
+Dice out! (roll 16, shooter 3)
 Shooter rolled 8 (5, 3)
 Player 1 won $14.0 on Place(8, amount=12.0)!
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
-Dice out!
+Dice out! (roll 17, shooter 3)
 Shooter rolled 3 (1, 2)
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
-Dice out!
+Dice out! (roll 18, shooter 3)
 Shooter rolled 7 (3, 4)
 Player 0 lost $5.0 on PassLine(amount=5.0).
 Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0).
@@ -136,14 +136,14 @@ Point is Off (None)
 Player 0: Bankroll=67.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=952.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 19, shooter 4)
 Shooter rolled 7 (3, 4)
 Player 0 won $5.0 on PassLine(amount=5.0)!
 Point is Off (None)
 Player 0: Bankroll=72.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=952.0, Bet amount=0, Bets=[]
 
-Dice out!
+Dice out! (roll 20, shooter 4)
 Shooter rolled 7 (3, 4)
 Player 0 won $5.0 on PassLine(amount=5.0)!
 Point is Off (None)


### PR DESCRIPTION
Closes #59

Summary:
- Updated the verbose output in Table simulations to include both roll number and shooter number.
- Before: "Dice out!"
- After:  "Dice out! (roll X, shooter Y)"

Implementation:
- Modified the print statement in Table to display roll and shooter counts.
- Integration test updated to match new verbose format.
- All other tests pass.

Testing:
- Ran pytest; all tests pass.
- Verified output interactively