### PR TITLE
Fix odds bet having result when the point is off

### DIFF
--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -544,7 +544,6 @@ class Odds(_WinningLosingNumbersBet):
                 return BetResult(
                     amount=self.amount, remove=True, bet_amount=self.amount
                 )
-                # TODO: should this be self.amount?
 
         return super().get_result(table)
 
@@ -611,9 +610,6 @@ class Odds(_WinningLosingNumbersBet):
             f"Odds(base_type={self.base_type}, number={self.number}, amount={self.amount}"
             f"{self._get_always_working_repr()}"
         )
-
-    # def __str__(self):
-    #     return f"Odds({self.base_type!s}, number={self.number}, {self.amount})"
 
 
 # Place bets ------------------------------------------------------------------

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -71,11 +71,15 @@ class BetResult:
     """The monetary value representing the bet outcome."""
     remove: bool
     """Flag indicating whether this bet result should be removed from table."""
+    bet_amount: float = 0
+    """The monetary value of the original bet size. Needed only for bets that 
+    push and return the wager to the player. Default is zero for quick 
+    results that can define wins and losses by comparing against zero."""
 
     @property
     def won(self) -> bool:
-        """Returns True if the bet won (positive amount)."""
-        return self.amount > 0
+        """Returns True if the bet won (amount more than initial bet)."""
+        return self.amount > self.bet_amount
 
     @property
     def lost(self) -> bool:
@@ -85,15 +89,12 @@ class BetResult:
     @property
     def pushed(self) -> bool:
         """Returns True if the bet tied (zero amount)."""
-        return self.amount == 0
+        return self.amount == self.bet_amount
 
     @property
     def bankroll_change(self) -> float:
         """Calculates the change to the bankroll (amount if bet won, zero otherwise)."""
-        if self.won:
-            return self.amount
-        else:
-            return 0
+        return self.amount if self.amount > 0 else 0
 
 
 class _MetaBetABC(ABCMeta):
@@ -232,7 +233,7 @@ class _WinningLosingNumbersBet(Bet, ABC):
             result_amount = 0
             should_remove = False
 
-        return BetResult(result_amount, should_remove)
+        return BetResult(result_amount, should_remove, self.amount)
 
     @abstractmethod
     def get_winning_numbers(self, table: Table) -> list[int]:
@@ -517,10 +518,12 @@ class Odds(_WinningLosingNumbersBet):
         base_type: typing.Type[PassLine | DontPass | Come | DontCome],
         number: int,
         amount: float,
+        always_working: bool = False,
     ):
         super().__init__(amount)
         self.base_type = base_type
         self.number = number
+        self.always_working = always_working
 
     @property
     def light_side(self) -> bool:
@@ -529,6 +532,21 @@ class Odds(_WinningLosingNumbersBet):
     @property
     def dark_side(self) -> bool:
         return issubclass(self.base_type, (DontPass, DontCome))
+
+    def get_result(self, table: Table) -> BetResult:
+
+        if table.point.status == "Off" and not self.always_working:
+
+            if table.dice.total in (
+                self.get_losing_numbers(table) + self.get_winning_numbers(table)
+            ):
+                # Bet "pushes" and returns to the player
+                return BetResult(
+                    amount=self.amount, remove=True, bet_amount=self.amount
+                )
+                # TODO: should this be self.amount?
+
+        return super().get_result(table)
 
     def get_winning_numbers(self, table: Table) -> list[int]:
         if self.light_side:
@@ -585,8 +603,11 @@ class Odds(_WinningLosingNumbersBet):
     def __repr__(self):
         return (
             f"Odds(base_type={self.base_type}, number={self.number}, "
-            f"amount={self.amount})"
+            f"amount={self.amount}, always_working={self.always_working})"
         )
+
+    # def __str__(self):
+    #     return f"Odds({self.base_type!s}, number={self.number}, {self.amount})"
 
 
 # Place bets ------------------------------------------------------------------
@@ -807,7 +828,7 @@ class HardWay(Bet):
         else:
             result_amount = 0
             should_remove = False
-        return BetResult(result_amount, should_remove)
+        return BetResult(result_amount, should_remove, self.amount)
 
     @property
     def winning_result(self) -> tuple[int, int]:
@@ -851,7 +872,7 @@ class Hop(Bet):
         else:
             result_amount = -1 * self.amount
             should_remove = True
-        return BetResult(result_amount, should_remove)
+        return BetResult(result_amount, should_remove, self.amount)
 
     @property
     def is_easy(self) -> bool:
@@ -902,7 +923,7 @@ class Fire(Bet):
     def get_result(self, table: Table) -> BetResult:
 
         if table.point.status == "Off":
-            return BetResult(amount=0, remove=False)
+            return BetResult(amount=0, remove=False, bet_amount=self.amount)
 
         if table.dice.total == table.point.number:
             self.points_made.add(table.point.number)
@@ -920,7 +941,7 @@ class Fire(Bet):
         else:
             result_amount = 0
 
-        return BetResult(result_amount, remove=ended)
+        return BetResult(result_amount, remove=ended, bet_amount=self.amount)
 
     def is_removable(self, table: Table) -> bool:
         """Fire bet is removable only if there is a new shooter.
@@ -968,7 +989,7 @@ class _ATSBet(Bet):
             result_amount = 0
             should_remove = False
 
-        return BetResult(result_amount, should_remove)
+        return BetResult(result_amount, should_remove, self.amount)
 
     def is_removable(self, table: Table) -> bool:
         """All/Tall/Small bets are removable only if there is a new shooter.

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -596,14 +596,20 @@ class Odds(_WinningLosingNumbersBet):
         ]
         return sum(x.amount for x in base_bets)
 
+    def _get_always_working_repr(self) -> str:
+        """Since the default is false, only need to print when True"""
+        return (
+            f", always_working={self.always_working})" if self.always_working else f")"
+        )
+
     @property
     def _placed_key(self) -> typing.Hashable:
         return type(self), self.base_type, self.number
 
     def __repr__(self):
         return (
-            f"Odds(base_type={self.base_type}, number={self.number}, "
-            f"amount={self.amount}, always_working={self.always_working})"
+            f"Odds(base_type={self.base_type}, number={self.number}, amount={self.amount}"
+            f"{self._get_always_working_repr()}"
         )
 
     # def __str__(self):

--- a/crapssim/strategy/odds.py
+++ b/crapssim/strategy/odds.py
@@ -37,7 +37,7 @@ class OddsAmount(Strategy):
             if bet.is_allowed(player) and not player.already_placed(bet):
                 player.add_bet(bet)
 
-    def get_always_working_repr(self) -> str:
+    def _get_always_working_repr(self) -> str:
         """Since the default is false, only need to print when True"""
         return (
             f", always_working={self.always_working})" if self.always_working else f")"
@@ -47,7 +47,7 @@ class OddsAmount(Strategy):
         return (
             f"{self.__class__.__name__}(base_type={self.base_type}, "
             f"odds_amounts={self.odds_amounts}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -65,7 +65,7 @@ class PassLineOddsAmount(OddsAmount):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -83,7 +83,7 @@ class DontPassOddsAmount(OddsAmount):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -101,7 +101,7 @@ class ComeOddsAmount(OddsAmount):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -119,7 +119,7 @@ class DontComeOddsAmount(OddsAmount):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -197,7 +197,7 @@ class OddsMultiplier(Strategy):
         """
         return len([x for x in player.bets if isinstance(x, self.base_type)]) == 0
 
-    def get_odds_multiplier_repr(self) -> int | dict[int, int]:
+    def _get_odds_multiplier_repr(self) -> int | dict[int, int]:
         """If the odds_multiplier has multiple values return a dictionary with the values,
         if all the multipliers are the same return an integer of the multiplier."""
         if all([x == self.odds_multiplier[4] for x in self.odds_multiplier.values()]):
@@ -206,7 +206,7 @@ class OddsMultiplier(Strategy):
             odds_multiplier = self.odds_multiplier
         return odds_multiplier
 
-    def get_always_working_repr(self) -> str:
+    def _get_always_working_repr(self) -> str:
         """Since the default is false, only need to print when True"""
         return (
             f", always_working={self.always_working})" if self.always_working else f")"
@@ -216,7 +216,7 @@ class OddsMultiplier(Strategy):
         return (
             f"{self.__class__.__name__}(base_type={self.base_type}, "
             f"odds_multiplier={self.get_odds_multiplier_repr()}"
-            f"{self.get_always_working_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -244,8 +244,8 @@ class PassLineOddsMultiplier(OddsMultiplier):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
-            f"{self.get_always_working_repr()}"
+            f"{self.__class__.__name__}(odds_multiplier={self._get_odds_multiplier_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -273,8 +273,8 @@ class DontPassOddsMultiplier(OddsMultiplier):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
-            f"{self.get_always_working_repr()}"
+            f"{self.__class__.__name__}(odds_multiplier={self._get_odds_multiplier_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -302,8 +302,8 @@ class ComeOddsMultiplier(OddsMultiplier):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
-            f"{self.get_always_working_repr()}"
+            f"{self.__class__.__name__}(odds_multiplier={self._get_odds_multiplier_repr()}"
+            f"{self._get_always_working_repr()}"
         )
 
 
@@ -331,6 +331,6 @@ class DontComeOddsMultiplier(OddsMultiplier):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
-            f"{self.get_always_working_repr()}"
+            f"{self.__class__.__name__}(odds_multiplier={self._get_odds_multiplier_repr()}"
+            f"{self._get_always_working_repr()}"
         )

--- a/crapssim/strategy/odds.py
+++ b/crapssim/strategy/odds.py
@@ -11,9 +11,11 @@ class OddsAmount(Strategy):
         self,
         base_type: typing.Type[PassLine | DontPass | Come | DontCome],
         odds_amounts: dict[int, typing.SupportsFloat],
+        always_working: bool = False,
     ):
         self.base_type = base_type
         self.odds_amounts = odds_amounts
+        self.always_working = always_working
 
     def completed(self, player: Player) -> bool:
         """Return True if there are no bets of base_type on the table.
@@ -31,9 +33,22 @@ class OddsAmount(Strategy):
 
     def update_bets(self, player: Player) -> None:
         for number, amount in self.odds_amounts.items():
-            bet = Odds(self.base_type, number, float(amount))
+            bet = Odds(self.base_type, number, float(amount), self.always_working)
             if bet.is_allowed(player) and not player.already_placed(bet):
                 player.add_bet(bet)
+
+    def get_always_working_repr(self) -> str:
+        """Since the default is false, only need to print when True"""
+        return (
+            f", always_working={self.always_working})" if self.always_working else f")"
+        )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(base_type={self.base_type}, "
+            f"odds_amounts={self.odds_amounts}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class PassLineOddsAmount(OddsAmount):
@@ -41,8 +56,17 @@ class PassLineOddsAmount(OddsAmount):
         self,
         bet_amount: typing.SupportsFloat,
         numbers: tuple[int] = (4, 5, 6, 8, 9, 10),
+        always_working: bool = False,
     ):
-        super().__init__(PassLine, {x: bet_amount for x in numbers})
+        self.bet_amount = float(bet_amount)
+        self.numbers = numbers
+        super().__init__(PassLine, {x: bet_amount for x in numbers}, always_working)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class DontPassOddsAmount(OddsAmount):
@@ -50,8 +74,17 @@ class DontPassOddsAmount(OddsAmount):
         self,
         bet_amount: typing.SupportsFloat,
         numbers: tuple[int] = (4, 5, 6, 8, 9, 10),
+        always_working: bool = False,
     ):
-        super().__init__(DontPass, {x: bet_amount for x in numbers})
+        self.bet_amount = float(bet_amount)
+        self.numbers = numbers
+        super().__init__(DontPass, {x: bet_amount for x in numbers}, always_working)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class ComeOddsAmount(OddsAmount):
@@ -59,8 +92,17 @@ class ComeOddsAmount(OddsAmount):
         self,
         bet_amount: typing.SupportsFloat,
         numbers: tuple[int] = (4, 5, 6, 8, 9, 10),
+        always_working: bool = False,
     ):
-        super().__init__(DontPass, {x: bet_amount for x in numbers})
+        self.bet_amount = float(bet_amount)
+        self.numbers = numbers
+        super().__init__(DontPass, {x: bet_amount for x in numbers}, always_working)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class DontComeOddsAmount(OddsAmount):
@@ -68,8 +110,17 @@ class DontComeOddsAmount(OddsAmount):
         self,
         bet_amount: typing.SupportsFloat,
         numbers: tuple[int] = (4, 5, 6, 8, 9, 10),
+        always_working: bool = False,
     ):
-        super().__init__(DontCome, {x: bet_amount for x in numbers})
+        self.bet_amount = float(bet_amount)
+        self.numbers = numbers
+        super().__init__(DontCome, {x: bet_amount for x in numbers}, always_working)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class OddsMultiplier(Strategy):
@@ -80,6 +131,7 @@ class OddsMultiplier(Strategy):
         self,
         base_type: typing.Type[PassLine | DontPass | Come | DontCome],
         odds_multiplier: dict[int, int] | int,
+        always_working: bool = False,
     ):
         """Takes an AllowsOdds item (ex. PassLine, Come, DontPass) and adds a BaseOdds bet
         (either Odds or LayOdds) based on the odds_multiplier given.
@@ -94,6 +146,7 @@ class OddsMultiplier(Strategy):
             determine what odds multiplier to use depending on the given point.
         """
         self.base_type = base_type
+        self.always_working = always_working
 
         if isinstance(odds_multiplier, int):
             self.odds_multiplier = {x: odds_multiplier for x in (4, 5, 6, 8, 9, 10)}
@@ -126,7 +179,9 @@ class OddsMultiplier(Strategy):
                 return
 
             amount = bet.amount * multiplier
-            OddsAmount(self.base_type, {point: amount}).update_bets(player)
+            OddsAmount(
+                self.base_type, {point: amount}, self.always_working
+            ).update_bets(player)
 
     def completed(self, player: Player) -> bool:
         """Return True if there are no bets of base_type on the table.
@@ -151,10 +206,17 @@ class OddsMultiplier(Strategy):
             odds_multiplier = self.odds_multiplier
         return odds_multiplier
 
+    def get_always_working_repr(self) -> str:
+        """Since the default is false, only need to print when True"""
+        return (
+            f", always_working={self.always_working})" if self.always_working else f")"
+        )
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(base_type={self.base_type}, "
-            f"odds_multiplier={self.get_odds_multiplier_repr()})"
+            f"odds_multiplier={self.get_odds_multiplier_repr()}"
+            f"{self.get_always_working_repr()}"
         )
 
 
@@ -162,7 +224,11 @@ class PassLineOddsMultiplier(OddsMultiplier):
     """Strategy that adds an Odds bet to the PassLine bet. Equivalent to
     OddsMultiplier(PassLine, odds)."""
 
-    def __init__(self, odds_multiplier: dict[int, int] | int | None = None):
+    def __init__(
+        self,
+        odds_multiplier: dict[int, int] | int | None = None,
+        always_working: bool = False,
+    ):
         """Add odds to PassLine bets with the multiplier specified by the odds_multiplier variable.
 
         Parameters
@@ -174,17 +240,24 @@ class PassLineOddsMultiplier(OddsMultiplier):
         """
         if odds_multiplier is None:
             odds_multiplier = {4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3}
-        super().__init__(PassLine, odds_multiplier)
+        super().__init__(PassLine, odds_multiplier, always_working)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()})"
+        return (
+            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class DontPassOddsMultiplier(OddsMultiplier):
     """Strategy that adds a LayOdds bet to the DontPass bet. Equivalent to
     OddsMultiplier(DontPass, odds)"""
 
-    def __init__(self, odds_multiplier: dict[int, int] | int | None = None):
+    def __init__(
+        self,
+        odds_multiplier: dict[int, int] | int | None = None,
+        always_working: bool = False,
+    ):
         """Add odds to DontPass bets with the multiplier specified by odds.
 
         Parameters
@@ -196,17 +269,24 @@ class DontPassOddsMultiplier(OddsMultiplier):
         """
         if odds_multiplier is None:
             odds_multiplier = 6
-        super().__init__(DontPass, odds_multiplier)
+        super().__init__(DontPass, odds_multiplier, always_working)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()})"
+        return (
+            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class ComeOddsMultiplier(OddsMultiplier):
     """Strategy that adds an Odds bet to the Come bet. Equivalent to
     OddsMultiplier(Come, odds)."""
 
-    def __init__(self, odds_multiplier: dict[int, int] | int | None = None):
+    def __init__(
+        self,
+        odds_multiplier: dict[int, int] | int | None = None,
+        always_working: bool = False,
+    ):
         """Add odds to Come bets with the multiplier specified by the odds_multiplier variable.
 
         Parameters
@@ -218,17 +298,24 @@ class ComeOddsMultiplier(OddsMultiplier):
         """
         if odds_multiplier is None:
             odds_multiplier = {4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3}
-        super().__init__(Come, odds_multiplier)
+        super().__init__(Come, odds_multiplier, always_working)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()})"
+        return (
+            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
+            f"{self.get_always_working_repr()}"
+        )
 
 
 class DontComeOddsMultiplier(OddsMultiplier):
     """Strategy that adds an Odds bet to the DontCome bet. Equivalent to
     OddsMultiplier(DontCome, odds)."""
 
-    def __init__(self, odds_multiplier: dict[int, int] | int | None = None):
+    def __init__(
+        self,
+        odds_multiplier: dict[int, int] | int | None = None,
+        always_working: bool = False,
+    ):
         """Add odds to DontCome bets with the multiplier specified by the odds_multiplier variable.
 
         Parameters
@@ -240,7 +327,10 @@ class DontComeOddsMultiplier(OddsMultiplier):
         """
         if odds_multiplier is None:
             odds_multiplier = 6
-        super().__init__(DontCome, odds_multiplier)
+        super().__init__(DontCome, odds_multiplier, always_working)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()})"
+        return (
+            f"{self.__class__.__name__}(odds_multiplier={self.get_odds_multiplier_repr()}"
+            f"{self.get_always_working_repr()}"
+        )

--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -462,3 +462,5 @@ class Player:
             print(f"{self.name} won ${result.amount - bet.amount} on {bet}!")
         elif result.lost:
             print(f"{self.name} lost ${bet.amount} on {bet}.")
+        elif result.pushed:
+            print(f"{self.name} pushed for ${bet.amount} on {bet}.")

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -748,14 +748,17 @@ def test_all_tall_small_table_payout_ratio(
     assert ratio == correct_ratio
 
 
-def test_odds_inactive_when_point_off():
+def test_odds_inactive_when_point_off_unless_always_working():
 
     table = Table()
-    strat = BetPassLine(10) + BetCome(10) + ComeOddsMultiplier()
+    strat1 = BetPassLine(10) + BetCome(10) + ComeOddsMultiplier()
+    strat2 = BetPassLine(10) + BetCome(10) + ComeOddsMultiplier(always_working=True)
 
-    table.add_player(bankroll=200, strategy=strat)
+    table.add_player(bankroll=200, strategy=strat1)
+    table.add_player(bankroll=200, strategy=strat2)
     table.fixed_run(
         dice_outcomes=[(5, 5), (5, 1), (5, 5), (5, 2), (3, 3)], verbose=True
     )
 
     assert table.players[0].bankroll == 190
+    assert table.players[1].bankroll == 110

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -25,6 +25,8 @@ from crapssim.bet import (
     Yo,
 )
 from crapssim.point import Point
+from crapssim.strategy.odds import ComeOddsMultiplier
+from crapssim.strategy.single_bet import BetCome, BetPassLine
 from crapssim.strategy.tools import NullStrategy
 from crapssim.table import TableUpdate
 
@@ -744,3 +746,16 @@ def test_all_tall_small_table_payout_ratio(
 
     ratio = (bet.get_result(table).amount - bet.amount) / bet.amount
     assert ratio == correct_ratio
+
+
+def test_odds_inactive_when_point_off():
+
+    table = Table()
+    strat = BetPassLine(10) + BetCome(10) + ComeOddsMultiplier()
+
+    table.add_player(bankroll=200, strategy=strat)
+    table.fixed_run(
+        dice_outcomes=[(5, 5), (5, 1), (5, 5), (5, 2), (3, 3)], verbose=True
+    )
+
+    assert table.players[0].bankroll == 190

--- a/tests/integration/verified_table_output.txt
+++ b/tests/integration/verified_table_output.txt
@@ -16,39 +16,39 @@ Player 1: Bankroll=1000.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 8 (2, 6)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=968.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 4 (2, 2)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 9 (4, 5)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 10 (4, 6)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 4 (1, 3)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=1004.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False).
 Player 1 lost $10.0 on Place(5, amount=10.0).
 Player 1 lost $12.0 on Place(6, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
@@ -59,19 +59,19 @@ Player 1: Bankroll=1004.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 6 (3, 3)
 Point is On (6)
-Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
+Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 2 (1, 1)
 Point is On (6)
-Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
+Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False).
 Player 1 lost $10.0 on Place(5, amount=10.0).
 Player 1 lost $12.0 on Place(8, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
@@ -82,13 +82,13 @@ Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 8 (6, 2)
 Point is On (8)
-Player 0: Bankroll=60.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
+Player 0: Bankroll=60.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
 Player 1: Bankroll=940.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 8 (6, 2)
 Player 0 won $5.0 on PassLine(amount=5.0)!
-Player 0 won $12.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)!
+Player 0 won $12.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)!
 Point is Off (None)
 Player 0: Bankroll=87.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
@@ -103,32 +103,32 @@ Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 5 (3, 2)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 11 (6, 5)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 8 (5, 3)
 Player 1 won $14.0 on Place(8, amount=12.0)!
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
 Dice out!
 Shooter rolled 3 (1, 2)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
 Dice out!
 Shooter rolled 7 (3, 4)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False).
 Player 1 lost $12.0 on Place(6, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
 Player 1 lost $12.0 on Place(8, amount=12.0).

--- a/tests/integration/verified_table_output.txt
+++ b/tests/integration/verified_table_output.txt
@@ -16,39 +16,39 @@ Player 1: Bankroll=1000.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 8 (2, 6)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=968.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 4 (2, 2)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 9 (4, 5)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 10 (4, 6)
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=986.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 4 (1, 3)
 Player 1 won $18.0 on Place(4, amount=10.0)!
 Point is On (8)
-Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=90.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=1004.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0).
 Player 1 lost $10.0 on Place(5, amount=10.0).
 Player 1 lost $12.0 on Place(6, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
@@ -59,19 +59,19 @@ Player 1: Bankroll=1004.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 6 (3, 3)
 Point is On (6)
-Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False)]
+Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 2 (1, 1)
 Point is On (6)
-Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False)]
+Player 0: Bankroll=75.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0)]
 Player 1: Bankroll=972.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 7 (4, 3)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0, always_working=False).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=6, amount=10.0).
 Player 1 lost $10.0 on Place(5, amount=10.0).
 Player 1 lost $12.0 on Place(8, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
@@ -82,13 +82,13 @@ Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 8 (6, 2)
 Point is On (8)
-Player 0: Bankroll=60.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)]
+Player 0: Bankroll=60.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)]
 Player 1: Bankroll=940.0, Bet amount=32.0, Bets=[Place(5, amount=10.0), Place(6, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 8 (6, 2)
 Player 0 won $5.0 on PassLine(amount=5.0)!
-Player 0 won $12.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0, always_working=False)!
+Player 0 won $12.0 on Odds(base_type=crapssim.bet.PassLine, number=8, amount=10.0)!
 Point is Off (None)
 Player 0: Bankroll=87.0, Bet amount=5.0, Bets=[PassLine(amount=5.0)]
 Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
@@ -103,32 +103,32 @@ Player 1: Bankroll=972.0, Bet amount=0, Bets=[]
 Dice out!
 Shooter rolled 5 (3, 2)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 11 (6, 5)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=938.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(8, amount=12.0), Place(4, amount=10.0)]
 
 Dice out!
 Shooter rolled 8 (5, 3)
 Player 1 won $14.0 on Place(8, amount=12.0)!
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
 Dice out!
 Shooter rolled 3 (1, 2)
 Point is On (5)
-Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False)]
+Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[PassLine(amount=5.0), Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0)]
 Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[Place(6, amount=12.0), Place(4, amount=10.0), Place(8, amount=12.0)]
 
 Dice out!
 Shooter rolled 7 (3, 4)
 Player 0 lost $5.0 on PassLine(amount=5.0).
-Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0, always_working=False).
+Player 0 lost $10.0 on Odds(base_type=crapssim.bet.PassLine, number=5, amount=10.0).
 Player 1 lost $12.0 on Place(6, amount=12.0).
 Player 1 lost $10.0 on Place(4, amount=10.0).
 Player 1 lost $12.0 on Place(8, amount=12.0).

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -62,19 +62,19 @@ def test_ev_oneroll(bet, ev):
         (crapssim.bet.DontCome(1), "DontCome(amount=1.0, number=None)"),
         (
             crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1, False),
-            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0, always_working=False)",
+            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.Come, 8, 1),
-            "Odds(base_type=crapssim.bet.Come, number=8, amount=1.0, always_working=False)",
+            "Odds(base_type=crapssim.bet.Come, number=8, amount=1.0)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.DontPass, 9, 1),
-            "Odds(base_type=crapssim.bet.DontPass, number=9, amount=1.0, always_working=False)",
+            "Odds(base_type=crapssim.bet.DontPass, number=9, amount=1.0)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.DontCome, 10, 1),
-            "Odds(base_type=crapssim.bet.DontCome, number=10, amount=1.0, always_working=False)",
+            "Odds(base_type=crapssim.bet.DontCome, number=10, amount=1.0)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1, True),

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -61,20 +61,36 @@ def test_ev_oneroll(bet, ev):
         (crapssim.bet.DontPass(1), "DontPass(amount=1.0)"),
         (crapssim.bet.DontCome(1), "DontCome(amount=1.0, number=None)"),
         (
-            crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1),
-            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0)",
+            crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1, False),
+            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0, always_working=False)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.Come, 8, 1),
-            "Odds(base_type=crapssim.bet.Come, number=8, amount=1.0)",
+            "Odds(base_type=crapssim.bet.Come, number=8, amount=1.0, always_working=False)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.DontPass, 9, 1),
-            "Odds(base_type=crapssim.bet.DontPass, number=9, amount=1.0)",
+            "Odds(base_type=crapssim.bet.DontPass, number=9, amount=1.0, always_working=False)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.DontCome, 10, 1),
-            "Odds(base_type=crapssim.bet.DontCome, number=10, amount=1.0)",
+            "Odds(base_type=crapssim.bet.DontCome, number=10, amount=1.0, always_working=False)",
+        ),
+        (
+            crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1, True),
+            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0, always_working=True)",
+        ),
+        (
+            crapssim.bet.Odds(crapssim.bet.Come, 8, 1, True),
+            "Odds(base_type=crapssim.bet.Come, number=8, amount=1.0, always_working=True)",
+        ),
+        (
+            crapssim.bet.Odds(crapssim.bet.DontPass, 9, 1, True),
+            "Odds(base_type=crapssim.bet.DontPass, number=9, amount=1.0, always_working=True)",
+        ),
+        (
+            crapssim.bet.Odds(crapssim.bet.DontCome, 10, 1, True),
+            "Odds(base_type=crapssim.bet.DontCome, number=10, amount=1.0, always_working=True)",
         ),
         (crapssim.bet.Place(4, 1), "Place(4, amount=1.0)"),
         (crapssim.bet.Place(5, 1), "Place(5, amount=1.0)"),

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -41,7 +41,13 @@ from crapssim.strategy.examples import (
     PlaceInside,
     Risk12,
 )
-from crapssim.strategy.odds import OddsAmount, OddsMultiplier
+from crapssim.strategy.odds import (
+    ComeOddsMultiplier,
+    DontComeOddsMultiplier,
+    DontPassOddsMultiplier,
+    OddsAmount,
+    OddsMultiplier,
+)
 from crapssim.strategy.single_bet import StrategyMode, _BaseSingleBet
 from crapssim.strategy.tools import RemoveByType, RemoveIfPointOff, ReplaceIfTrue
 
@@ -570,6 +576,22 @@ def test_odds_multiplier_dont_come_bet_placed(player):
     player.add_bet = MagicMock()
     strategy.update_bets(player)
     player.add_bet.assert_called_with(Odds(DontCome, 6, 30))
+
+
+def test_come_odds_multiplier_always_working_argument_passes_through(player):
+    strategy = ComeOddsMultiplier(1, always_working=True)
+    player.bets = [Come(5, 6)]
+    player.add_bet = MagicMock()
+    strategy.update_bets(player)
+    player.add_bet.assert_called_with(Odds(Come, 6, 5, always_working=True))
+
+
+def test_dontcome_odds_multiplier_always_working_argument_passes_through(player):
+    strategy = DontComeOddsMultiplier(1, always_working=True)
+    player.bets = [DontCome(5, 6)]
+    player.add_bet = MagicMock()
+    strategy.update_bets(player)
+    player.add_bet.assert_called_with(Odds(DontCome, 6, 5, always_working=True))
 
 
 def test_base_single_bet_add_if_non_existent_add(player):
@@ -1300,6 +1322,85 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         (
             crapssim.strategy.examples.Place68DontCome2Odds(6, 5),
             "Place68DontCome2Odds(six_eight_amount=6.0, dont_come_amount=5.0)",
+        ),
+        # Odds strategies
+        (
+            crapssim.strategy.odds.OddsAmount(
+                PassLine, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
+            ),
+            "OddsAmount(base_type=crapssim.bet.PassLine, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+        ),
+        (
+            crapssim.strategy.odds.OddsAmount(
+                PassLine, {x: 10 for x in (4, 5, 6, 8, 9, 10)}, always_working=True
+            ),
+            "OddsAmount(base_type=crapssim.bet.PassLine, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10}, always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.OddsAmount(
+                Come, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
+            ),
+            "OddsAmount(base_type=crapssim.bet.Come, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+        ),
+        (
+            crapssim.strategy.odds.OddsAmount(
+                DontPass, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
+            ),
+            "OddsAmount(base_type=crapssim.bet.DontPass, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+        ),
+        (
+            crapssim.strategy.odds.OddsAmount(
+                DontCome, {x: 10 for x in (4, 5, 6, 8, 9, 10)}, always_working=True
+            ),
+            "OddsAmount(base_type=crapssim.bet.DontCome, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10}, always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.PassLineOddsAmount(10),
+            "PassLineOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+        ),
+        (
+            crapssim.strategy.odds.PassLineOddsAmount(10, always_working=True),
+            "PassLineOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.ComeOddsAmount(10, always_working=True),
+            "ComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.ComeOddsAmount(10),
+            "ComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+        ),
+        (
+            crapssim.strategy.odds.DontPassOddsAmount(10),
+            "DontPassOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+        ),
+        (
+            crapssim.strategy.odds.DontComeOddsAmount(10),
+            "DontComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+        ),
+        (
+            crapssim.strategy.odds.PassLineOddsMultiplier(),
+            "PassLineOddsMultiplier(odds_multiplier={4: 3, 5: 4, 6: 5, 8: 5, 9: 4, 10: 3})",
+        ),
+        (
+            crapssim.strategy.odds.PassLineOddsMultiplier(2),
+            "PassLineOddsMultiplier(odds_multiplier=2)",
+        ),
+        (
+            crapssim.strategy.odds.PassLineOddsMultiplier(2, always_working=True),
+            "PassLineOddsMultiplier(odds_multiplier=2, always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.ComeOddsMultiplier(2, always_working=True),
+            "ComeOddsMultiplier(odds_multiplier=2, always_working=True)",
+        ),
+        (
+            crapssim.strategy.odds.DontPassOddsMultiplier(2),
+            "DontPassOddsMultiplier(odds_multiplier=2)",
+        ),
+        (
+            crapssim.strategy.odds.DontComeOddsMultiplier(2, always_working=True),
+            "DontComeOddsMultiplier(odds_multiplier=2, always_working=True)",
         ),
     ],
 )


### PR DESCRIPTION
Default table behavior is that odds are not working or "off" when the point is off. So the odds on a come bet on a come-out seven will return to the player. 

Fixes #54 

High level changes:
* Odds bet gains new argument `always_working` which controls behavior when point off (default False)
* All odds strategies gain new argument `always_working` which flows through to odds bet (default False)
* __repr__ methods will print this new argument only when True (not default)
* Add testing to check and cover the new interface
* Adjust BetResult method. New argument `bet_amount` (default 0) that is used to determine wins and push