### PR TITLE
Fix: DontPass and DontCome push on come-out 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+*  `DontPass` and `DontCome` bets will now "push" on a come-out 12, bringing the bet down and returing the bet amount to the player. `_WinningLosingNumbersBet` gains `get_push_numbers()` method to accomodate. 
 *  `OddsMultiplier `__repr__` logic so that floats, ints, and incomplete dictionaries all work for odds/win multiplier
  
 ## [0.3.2] - 2025-10-11

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -252,6 +252,9 @@ class _WinningLosingNumbersBet(Bet, ABC):
         elif table.dice.total in self.get_losing_numbers(table):
             result_amount = -1 * self.amount
             should_remove = True
+        elif table.dice.total in self.get_push_numbers(table):
+            result_amount = self.amount
+            should_remove = True
         else:
             result_amount = 0
             should_remove = False
@@ -267,6 +270,10 @@ class _WinningLosingNumbersBet(Bet, ABC):
     def get_losing_numbers(self, table: Table) -> list[int]:
         """Returns the losing numbers, based on table features"""
         pass
+
+    def get_push_numbers(self, table: Table) -> list[int]:
+        """Returns the push numbers, based on table features"""
+        return []
 
     @abstractmethod
     def get_payout_ratio(self, table: Table) -> float:
@@ -439,8 +446,6 @@ class DontPass(_WinningLosingNumbersBet):
     The opposite of the Pass Line bet. The player wins if the first roll is 2 or 3,
     pushes on 12, and loses if the first roll is 7 or 11. After a point is
     established, the player wins by rolling a 7 before the point number. Bet pays 1 to 1.
-
-    Note that a push will keep the bet active and not result in any change to bankroll.
     """
 
     def get_winning_numbers(self, table: Table) -> list[int]:
@@ -460,6 +465,11 @@ class DontPass(_WinningLosingNumbersBet):
         if table.point.number is None:
             return [7, 11]
         return [table.point.number]
+
+    def get_push_numbers(self, table: "Table") -> list[int]:
+        if table.point.number is None:
+            return [12]
+        return []
 
     def get_payout_ratio(self, table: Table) -> float:
         """Don't pass always pays out 1:1"""
@@ -502,6 +512,11 @@ class DontCome(_WinningLosingNumbersBet):
         if self.number is None:
             return [7, 11]
         return [self.number]
+
+    def get_push_numbers(self, table: "Table") -> list[int]:
+        if self.number is None:
+            return [12]
+        return []
 
     def get_payout_ratio(self, table: Table) -> float:
         """Don't Come always pays out 1:1"""

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -590,6 +590,42 @@ def test_passline_on_table(
     )
 
 
+@pytest.mark.parametrize(
+    "rolls, correct_bankroll_change, correct_value_change, correct_exists",
+    [
+        ([(6, 6)], 0, 0, False),
+        ([(1, 1)], 10, 10, False),
+        ([(3, 3)], -10, 0, True),
+        ([(3, 4)], -10, -10, False),
+    ],
+)
+# fmt: on
+def test_dontpass_on_table(
+    rolls: list[tuple[int]],
+    correct_bankroll_change: float,
+    correct_value_change: float,
+    correct_exists: bool,
+):
+
+    table = Table()
+    start_bankroll = 100
+    table.add_player(bankroll=start_bankroll, strategy=NullStrategy())
+    player = table.players[0]
+    player.add_bet(DontPass(10))
+
+    table.fixed_run(rolls, verbose=True)
+
+    bankroll_change = player.bankroll - start_bankroll
+    value_change = player.bankroll + player.total_bet_amount - start_bankroll
+    exists = player.has_bets(DontPass)
+
+    assert (bankroll_change, value_change, exists) == (
+        correct_bankroll_change,
+        correct_value_change,
+        correct_exists,
+    )
+
+
 # fmt: off
 @pytest.mark.parametrize('rolls, correct_bankroll_change, correct_value_change, correct_exists', [
     (

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -423,3 +423,31 @@ def test_combined_bet_equality(bets_1, bets_2):
             outcomes_2.append(sum(b.get_result(t).bankroll_change for b in bets_2))
 
     assert outcomes_1 == outcomes_2
+
+
+def test_dont_pass_bet_pushes_on_comeout_12():
+    table = Table()
+    table.add_player()
+    dont_pass_bet = crapssim.bet.DontPass(10)
+    table.players[0].add_bet(dont_pass_bet)
+
+    # Roll a 12 on the come-out roll
+    table.dice.fixed_roll((6, 6))
+    result = dont_pass_bet.get_result(table)
+
+    assert result.pushed
+    assert result.bankroll_change == dont_pass_bet.amount
+
+
+def test_dont_come_bet_pushes_on_12():
+    table = Table()
+    table.add_player()
+    dont_come_bet = DontCome(10)
+    table.players[0].add_bet(dont_come_bet)
+
+    # Roll a 12 on the come-out roll
+    table.dice.fixed_roll((6, 6))
+    result = dont_come_bet.get_result(table)
+
+    assert result.pushed
+    assert result.bankroll_change == dont_come_bet.amount


### PR DESCRIPTION
 `DontPass` and `DontCome` bets will now "push" on a come-out 12, bringing the bet down and returing the bet amount to the player. 

* `_WinningLosingNumbersBet` gains `get_push_numbers()` method and `get_result()` incorporates this method
* Add some testing to cover this (also looked at examples)

Thanks to @brl0 where I first saw this issue/fix: https://github.com/brl0/crapssim/tree/brl_20230909