### PR TITLE
Lay bets should charge vig based on win amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *  `DontPass` and `DontCome` bets will now "push" on a come-out 12, bringing the bet down and returing the bet amount to the player. `_WinningLosingNumbersBet` gains `get_push_numbers()` method to accomodate. 
+*  The `Risk12` strategy will now take down place bets after hitting point (i.e. place bets not working), which is aligned to table conventions
 *  `OddsMultiplier `__repr__` logic so that floats, ints, and incomplete dictionaries all work for odds/win multiplier
  
 ## [0.3.2] - 2025-10-11

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -820,6 +820,9 @@ class Lay(_SimpleBet):
     """True-odds bet against 4/5/6/8/9/10, paying if 7 arrives first.
 
     Commission may be taken on the win or upfront based on ``vig_paid_on_win``.
+    Note that the vig is taken on the amount won, not the bet amount,
+    since this is typically done in a casino (e.g. Laying the 4 for $40, which
+    pays $20, would have a $1 vig).
     """
 
     true_odds = {4: 0.5, 10: 0.5, 5: 2 / 3, 9: 2 / 3, 6: 5 / 6, 8: 5 / 6}
@@ -836,7 +839,8 @@ class Lay(_SimpleBet):
 
     def vig(self, table: "Table") -> float:
         rounding, floor = _vig_policy(table.settings)
-        return _compute_vig(self.amount, rounding=rounding, floor=floor)
+        gross_win = self.amount * self.payout_ratio
+        return _compute_vig(gross_win, rounding=rounding, floor=floor)
 
     def cost(self, table: "Table") -> float:
         if table.settings.get("vig_paid_on_win", True):

--- a/docs/supported-bets.md
+++ b/docs/supported-bets.md
@@ -47,7 +47,7 @@ This can be specified with the `"field_payouts"` option of the TableSettings, wh
 
 ### Buy/Lay bets and the vig (commission)
 
-This simulator uses a fixed 5% commission for applicable bets (e.g., Buy/Lay) to match common table practice. 
+This simulator uses a fixed 5% commission for applicable bets (e.g., Buy/Lay). This is 5% of the **bet amount** for Buy bets, and 5% of the potential **win amount** for Lay bets, as per common practice. For example, a \$20 Buy bet on the 4 and a \$40 Lay bet on the 4 (which wins \$20) both have a \$1 vig. 
 
 The `vig` is added to the bet `amount` to equal the bet's `cost`. 
 


### PR DESCRIPTION
Minor fix to #73 

* Adjust lay bets to charge the vig based on the win amount (not the bet amount).
* Add test to catch this
* Include information in docs and supported-bets page