### PR TITLE
Add `PlaceHitProgression` strategy tool and corresponding examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Personal strategy sandbox (not part of the package)
-sandbox/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -174,5 +171,5 @@ reports/
 **/reports/
 # End reports ignore
 
-# Sandbox files for local testing (do not commit)
+# Sandbox files for personcal/local testing (do not commit)
 sandbox/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Personal strategy sandbox (not part of the package)
+sandbox/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ Initial version
 [#82]: https://github.com/skent259/crapssim/pull/71
 [#83]: https://github.com/skent259/crapssim/pull/71
 [#86]: https://github.com/skent259/crapssim/pull/86
-[#86]: https://github.com/skent259/crapssim/pull/87
+[#87]: https://github.com/skent259/crapssim/pull/87
 
 [#48]: https://github.com/skent259/crapssim/issues/48
 [#53]: https://github.com/skent259/crapssim/issues/53

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Support for Crapless craps via new `rules` module, with corresponding updates across table and bet from [@tyemerick88] in [#86]
 * Expanded the test suite with new unit and integration tests to improve coverage from [@tyemerick88] in [#86]
+* `PlaceHitProgression` strategy tool: For strategies built from place bets that change after each hit in predictable stages from [@skent259] in [#87]
+  * `SqueezePlay` strategy example: $66 inside -> add 4/10 -> Press inside -> Regress to $64 across
+  * `DoubleTap` strategy example: presses each place number twice then regresses, with every number progressing independently on its own hits
+
+### Fixed
+
+* `AggregateStrategy` now forwards `after_roll` to its substrategies, so composed strategies that count wins or detect a seven-out in `after_roll` observe the roll [#87]
 
 
 ## [0.4.0] - 2025-11-18
@@ -153,6 +160,7 @@ Initial version
 [#82]: https://github.com/skent259/crapssim/pull/71
 [#83]: https://github.com/skent259/crapssim/pull/71
 [#86]: https://github.com/skent259/crapssim/pull/86
+[#86]: https://github.com/skent259/crapssim/pull/87
 
 [#48]: https://github.com/skent259/crapssim/issues/48
 [#53]: https://github.com/skent259/crapssim/issues/53

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -68,8 +68,10 @@ class Table(Protocol):
 
 
 class Player(Protocol):
-    table: Table
     bets: list["Bet"]
+
+    @property
+    def table(self) -> Table: ...
 
     @property
     def bankroll(self) -> float: ...

--- a/crapssim/strategy/__init__.py
+++ b/crapssim/strategy/__init__.py
@@ -21,6 +21,7 @@ from crapssim.strategy.tools import (
     AddIfTrue,
     AggregateStrategy,
     CountStrategy,
+    PlaceHitProgression,
     RemoveIfPointOff,
     RemoveIfTrue,
     Strategy,

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -31,6 +31,7 @@ from crapssim.strategy.tools import (
     AddIfTrue,
     AggregateStrategy,
     CountStrategy,
+    PlaceHitProgression,
     Player,
     RemoveByType,
     Strategy,
@@ -925,3 +926,53 @@ class ThreePointDolly(AggregateStrategy):
             f"{self.__class__.__name__}(amount={self.bet_amount}, "
             f"win_multiplier={self.win_multiplier})"
         )
+
+
+class SqueezePlay(PlaceHitProgression):
+    """Gets you from $66 inside to $64 across all paid within 3 rolls.
+
+    A place-betting progression (no pass line) that starts with $66 inside, adds
+    the 4 and 10 after the first hit, presses the inside numbers to $88 after the
+    second hit, and regresses everything to a flat $64 across after the third
+    hit. The intent is to recover the initial outlay quickly and then hold a
+    lower-risk board::
+
+        0 hits  Place $66 inside:  5@$15, 6@$18, 8@$18, 9@$15
+        1 hit   Add the 4 and 10:  ... plus 4@$10, 10@$10
+        2 hits  Press inside to $88: 5@$20, 6@$24, 8@$24, 9@$20 (4 & 10 stay $10)
+        3+ hits Regress to $64 across: 4@$10, 5@$10, 6@$12, 8@$12, 9@$10, 10@$10
+
+    Implemented as a :class:`~crapssim.strategy.tools.PlaceHitProgression`, so the
+    progression carries across made points and resets only on a seven-out. Because
+    the inside numbers include the point when it is 5, 6, 8, or 9, rolling the
+    point both pays the Place bet and makes the point; that hit still counts
+    toward the goal since a made point no longer resets the progression. While the
+    point is off (the come-out) the place bets are taken down so a come-out seven
+    can't sweep them, then rebuilt at the current stage once a new point is on.
+
+    Buy-in of $500 at a $10 table minimum comfortably covers the largest board.
+
+    Strategy Source: https://www.marconius.com/craps/#squeeze
+
+    See Also:
+        :class:`~crapssim.strategy.tools.PlaceHitProgression`
+    """
+
+    _INSIDE_INITIAL = {5: 15.0, 6: 18.0, 8: 18.0, 9: 15.0}  # $66 inside
+    _INSIDE_PRESSED = {5: 20.0, 6: 24.0, 8: 24.0, 9: 20.0}  # $88 inside
+    _OUTSIDE = {4: 10.0, 10: 10.0}
+    _ACROSS_FINAL = {4: 10.0, 5: 10.0, 6: 12.0, 8: 12.0, 9: 10.0, 10: 10.0}  # $64 across
+
+    def __init__(self) -> None:
+        """Build the fixed four-stage squeeze progression."""
+        super().__init__(
+            stages=[
+                self._INSIDE_INITIAL,  # 0 hits: $66 inside
+                {**self._INSIDE_INITIAL, **self._OUTSIDE},  # 1 hit: add 4 and 10
+                {**self._INSIDE_PRESSED, **self._OUTSIDE},  # 2 hits: press to $88
+                self._ACROSS_FINAL,  # 3+ hits: $64 across
+            ]
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -977,3 +977,60 @@ class SqueezePlay(PlaceHitProgression):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
+
+
+class DoubleTap(AggregateStrategy):
+    """Press each place number twice, collect, and repeat -- independently.
+
+    Every place number runs its own "double tap" progression that presses on a
+    hit, presses again on the next, then regresses to the starting amount on the
+    third (the "double tap" before taking the profit down), and repeats. Each
+    number advances only on its own hits, so a hot 6 climbs while a cold 4 sits
+    at its base amount. At the default ``base_amount`` of $10::
+
+        6 and 8:      12 -> 24 -> 48 -> 12 -> 24 -> 48 -> 12
+        4, 5, 9, 10:  10 -> 20 -> 40 -> 10 -> 20 -> 40 -> 10
+
+    The outside numbers (4, 5, 9, 10) start at ``base_amount``; the 6 and 8 start
+    near ``6 / 5 * base_amount``, rounded to the nearest $6 increment so their 7:6
+    payouts stay whole. In both cases the pattern is the same: double the starting
+    bet twice, then drop back to the start. Every number is an independent
+    :class:`~crapssim.strategy.tools.PlaceHitProgression`, so each progression
+    carries across made points and they all reset to their base amounts on a
+    seven-out.
+
+    Args:
+        base_amount: Starting amount for the outside numbers. Should be a multiple
+            of $5 so the 4, 5, 9, and 10 pay whole. Defaults to 10.
+
+    See Also:
+        :class:`~crapssim.strategy.tools.PlaceHitProgression`
+    """
+
+    # Multipliers applied to the starting bet: double twice, then back to start.
+    _SIX_EIGHT_MULTIPLIERS = (1, 2, 4, 1, 2, 4, 1)
+    _OUTSIDE_MULTIPLIERS = (1, 2, 4, 1, 2, 4, 1)
+
+    def __init__(self, base_amount: float = 10.0) -> None:
+        """Build one independent double-tap progression per place number."""
+        self.base_amount = float(base_amount)
+        # 6 and 8 pay 7:6, so their bets must be multiples of $6.
+        six_eight_base = 6/5 * self.base_amount
+
+        progressions = []
+        for number in (6, 8):
+            stages = [
+                {number: multiplier * six_eight_base}
+                for multiplier in self._SIX_EIGHT_MULTIPLIERS
+            ]
+            progressions.append(PlaceHitProgression(stages))
+        for number in (4, 5, 9, 10):
+            stages = [
+                {number: multiplier * self.base_amount}
+                for multiplier in self._OUTSIDE_MULTIPLIERS
+            ]
+            progressions.append(PlaceHitProgression(stages))
+        super().__init__(*progressions)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(base_amount={self.base_amount})"

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -119,9 +119,10 @@ class PlaceInside(AggregateStrategy):
             or a number that supports float. If its a number that supports float, the six and eight
             amounts will be the number * (6 / 5) to make the payout a whole number.
         """
+        self.bet_amount: float | dict[int, float]
         if isinstance(bet_amount, SupportsFloat):
             self.bet_amount = float(bet_amount)
-            six_eight_amount = bet_amount * (6 / 5)
+            six_eight_amount = self.bet_amount * (6 / 5)
             amount_dict = {
                 5: self.bet_amount,
                 6: six_eight_amount,
@@ -850,7 +851,7 @@ class ThreePointMolly(AggregateStrategy):
     ):
 
         self.bet_amount: float = float(bet_amount)
-        self.odds_multiplier: float = (
+        self.odds_multiplier: float | None = (
             float(odds_multiplier) if odds_multiplier is not None else None
         )
 
@@ -904,7 +905,7 @@ class ThreePointDolly(AggregateStrategy):
     ):
 
         self.bet_amount: float = float(bet_amount)
-        self.win_multiplier: float = (
+        self.win_multiplier: float | None = (
             float(win_multiplier) if win_multiplier is not None else None
         )
 

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -24,6 +24,7 @@ __all__ = [
     "RemoveIfPointOff",
     "RemoveByType",
     "WinProgression",
+    "PlaceHitProgression",
 ]
 
 
@@ -540,3 +541,146 @@ class WinProgression(Strategy):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(first_bet={self.bet}, multipliers={self.multipliers})"
+
+
+class PlaceHitProgression(Strategy):
+    """Advance through a sequence of Place-bet boards as numbers hit.
+
+    You define a list of *stages* -- one set of place bets per number of hits
+    scored so far. Each stage is a ``{number: amount}`` dictionary describing the
+    Place bets that should be working while the strategy is at that hit count::
+
+        stages[0]   # board before any number has hit
+        stages[1]   # board after the 1st hit
+        ...
+        stages[-1]  # held once hit_count reaches len(stages) - 1
+
+    The strategy advances one stage each time one of the numbers it *owns* wins.
+    The owned numbers are the union of every number appearing across all stages;
+    the strategy only counts hits on, reconciles, and removes bets on those
+    numbers, leaving every other bet on the table untouched. This makes instances
+    composable: combine several with **disjoint** number sets in an
+    :class:`AggregateStrategy` and each progresses independently (for example a
+    Place-6 progression running alongside an unrelated Place-8 progression).
+
+    The progression carries across made points -- while the point is off (the
+    come-out) the owned Place bets are taken down so a come-out seven can't sweep
+    them, and they are rebuilt at the same stage once a new point is on. Only a
+    seven-out resets the progression back to ``stages[0]``.
+
+    Note:
+        Composed instances must use disjoint number sets. Two instances that both
+        own the same number would each try to reconcile it and would double-count
+        its hits.
+
+    See Also:
+        :class:`WinProgression`
+        :class:`~crapssim.strategy.examples.SqueezePlay`
+    """
+
+    def __init__(self, stages: list[dict[int, float]]) -> None:
+        """Configure the per-hit board sequence.
+
+        Args:
+            stages: A non-empty list of ``{number: amount}`` boards, indexed by
+                the number of hits scored so far. The last stage is held once the
+                hit count reaches or exceeds ``len(stages) - 1``.
+
+        Raises:
+            ValueError: If ``stages`` is empty.
+        """
+        if not stages:
+            raise ValueError("stages must contain at least one board configuration")
+        self.stages: list[dict[int, float]] = [dict(stage) for stage in stages]
+        self.numbers: frozenset[int] = frozenset(
+            number for stage in self.stages for number in stage
+        )
+        self.hit_count: int = 0
+        self._seven_out: bool = False
+
+    def _target(self) -> dict[int, float]:
+        """Return the board that should be working at the current hit count."""
+        index = min(self.hit_count, len(self.stages) - 1)
+        return self.stages[index]
+
+    def _owned_place_bets(self, player: Player) -> list[Place]:
+        """Return the player's Place bets on the numbers this strategy owns."""
+        return [
+            bet
+            for bet in player.bets
+            if isinstance(bet, Place) and bet.number in self.numbers
+        ]
+
+    def _clear_owned(self, player: Player) -> None:
+        """Remove all of this strategy's Place bets from the table."""
+        for bet in self._owned_place_bets(player):
+            player.remove_bet(bet)
+
+    def completed(self, player: Player) -> bool:
+        """Return whether the strategy can no longer continue.
+
+        Args:
+            player: The player whose bankroll and bets to check.
+
+        Returns:
+            True if the bankroll can't cover the smallest configured bet and no
+            bets remain on the table, otherwise False.
+        """
+        smallest_bet = min(
+            amount for stage in self.stages for amount in stage.values()
+        )
+        return player.bankroll < smallest_bet and len(player.bets) == 0
+
+    def after_roll(self, player: Player) -> None:
+        """Flag a seven-out or count a hit on an owned number.
+
+        A seven-out is the only event that resets the progression. Runs after the
+        roll but before the bets and point settle, so ``point.status`` still holds
+        its pre-roll value.
+
+        Args:
+            player: The player to check for winning bets.
+        """
+        table = player.table
+        if table.point.status == "On" and table.dice.total == 7:
+            self._seven_out = True
+            return
+        if table.point.status == "Off":
+            return
+        for bet in self._owned_place_bets(player):
+            if bet.get_result(table).won:
+                self.hit_count += 1
+                break  # at most one number wins per roll
+
+    def update_bets(self, player: Player) -> None:
+        """Reconcile the owned numbers to the board for the current hit count.
+
+        On a seven-out the board is cleared and the progression restarts. During
+        the come-out the owned bets are taken down but the progression is
+        preserved. Otherwise the owned bets are brought in line with the current
+        stage: a bet whose amount no longer matches the stage (a press or regress)
+        is removed and re-added, and any missing number is placed. A winning Place
+        bet is taken down by the table each roll, so this also re-adds it.
+
+        Args:
+            player: The player to update the bets for.
+        """
+        if self._seven_out:
+            self._clear_owned(player)
+            self.hit_count = 0
+            self._seven_out = False
+            return
+
+        if player.table.point.status == "Off":
+            self._clear_owned(player)
+            return
+
+        target = self._target()
+        for bet in self._owned_place_bets(player):
+            if target.get(bet.number) != bet.amount:
+                player.remove_bet(bet)
+        for number, amount in target.items():
+            AddIfNotBet(Place(number, amount)).update_bets(player)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(stages={self.stages})"

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -3,11 +3,13 @@ strategies with the intended usage. Each of the strategies included in this pack
 to be used as building blocks when creating strategies."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Callable, Protocol, SupportsFloat
 
-from crapssim.bet import Bet, HardWay, Hop, Place
+from crapssim.bet import Bet, HardWay, Hop, Place, TableSettings
 from crapssim.dice import Dice
 from crapssim.point import Point
+from crapssim.rules import Rules
 
 __all__ = [
     "Strategy",
@@ -34,6 +36,8 @@ class Table(Protocol):
     dice: Dice
     point: Point
     new_shooter: bool
+    settings: TableSettings
+    rules: Rules
 
 
 class Player(Protocol):
@@ -456,33 +460,37 @@ class RemoveIfPointOff(RemoveIfTrue):
         Args:
             bet: Bet instance describing which wagers to remove when the point is off.
         """
-        if not any([isinstance(bet, x) for x in [Place, HardWay, Hop]]):
-            key = (
-                lambda b, p: isinstance(b, type(self.bet))
-                and p.table.point.status == "Off"
-            )
-
+        self.bet = bet
+        key: Callable[[Bet, Player], bool]
         if isinstance(bet, Place):
+            number = bet.number
             key = (
                 lambda b, p: isinstance(b, Place)
-                and b.number == self.bet.number
+                and b.number == number
                 and p.table.point.status == "Off"
             )
-        if isinstance(bet, HardWay):
+        elif isinstance(bet, HardWay):
+            number = bet.number
             key = (
                 lambda b, p: isinstance(b, HardWay)
-                and b.number == self.bet.number
+                and b.number == number
                 and p.table.point.status == "Off"
             )
-        if isinstance(bet, Hop):
+        elif isinstance(bet, Hop):
+            result = bet.result
             key = (
                 lambda b, p: isinstance(b, Hop)
-                and b.result == self.bet.result
+                and b.result == result
+                and p.table.point.status == "Off"
+            )
+        else:
+            bet_type = type(bet)
+            key = (
+                lambda b, p: isinstance(b, bet_type)
                 and p.table.point.status == "Off"
             )
 
         super().__init__(key)
-        self.bet = bet
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(bet={self.bet})"
@@ -500,7 +508,7 @@ class WinProgression(Strategy):
     """Strategy that every time a bet is won, moves to the next amount in the progression and
     places a Field bet for that amount."""
 
-    def __init__(self, first_bet: Bet, multipliers: list[SupportsFloat]) -> None:
+    def __init__(self, first_bet: Bet, multipliers: Sequence[SupportsFloat]) -> None:
         """Configure the baseline bet and multiplier progression.
 
         Args:
@@ -532,10 +540,10 @@ class WinProgression(Strategy):
         """Ensure a bet exists scaled by the current progression step."""
         new_bet = self.bet.copy()
         if self.current_progression >= len(self.multipliers):
-            new_bet.amount = self.bet.amount * self.multipliers[-1]
+            new_bet.amount = self.bet.amount * float(self.multipliers[-1])
         else:
-            new_bet.amount = (
-                self.bet.amount * self.multipliers[self.current_progression]
+            new_bet.amount = self.bet.amount * float(
+                self.multipliers[self.current_progression]
             )
         AddIfNotBet(new_bet).update_bets(player)
 

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -115,6 +115,23 @@ class AggregateStrategy(Strategy):
         """
         self.strategies = strategies
 
+    def after_roll(self, player: Player) -> None:
+        """Forward the after_roll hook to each strategy that has not completed.
+
+        Without this, substrategies that rely on :func:`Strategy.after_roll` (to
+        count winning bets, track winnings, detect a seven-out, etc.) would never
+        observe the roll when combined into an AggregateStrategy, since the base
+        :func:`Strategy.after_roll` is a no-op.
+
+        Parameters
+        ----------
+        player
+            The player to run each substrategy's after_roll for.
+        """
+        for strategy in self.strategies:
+            if not strategy.completed(player):
+                strategy.after_roll(player)
+
     def update_bets(self, player: Player) -> None:
         """Go through each of the strategies and run its update_bets method if the strategy has
         not been completed.

--- a/tests/integration/test_squeezeplay_integration.py
+++ b/tests/integration/test_squeezeplay_integration.py
@@ -8,7 +8,7 @@ regress, the carry-across-made-points behavior, and the seven-out reset.
 import pytest
 
 from crapssim.strategy import PlaceHitProgression
-from crapssim.strategy.examples import SqueezePlay
+from crapssim.strategy.examples import DoubleTap, SqueezePlay
 from crapssim.table import Table
 
 BUY_IN = 500.0
@@ -83,3 +83,32 @@ def test_independent_progressions_press_separately():
 
     # The 6 pressed to $24 on its own hits; the untouched 8 stayed at $12.
     assert bets == ["$12 Place(8)", "$24 Place(6)"]
+
+
+def test_double_tap_presses_and_regresses_per_number():
+    """DoubleTap presses each number twice then regresses, independently."""
+    table = Table()
+    player = table.add_player(bankroll=2000.0, strategy=DoubleTap())
+    # pt 4 (outside, so inside hits don't make the point); hit the 6 three times
+    # (12 -> 24 -> 48 -> regress to 12), with a trailing non-scoring roll.
+    table.fixed_run(
+        dice_outcomes=[(2, 2), (3, 3), (2, 4), (3, 3), (1, 1)], verbose=False
+    )
+    bets = {b.number: b.amount for b in player.bets}
+
+    # The 6 double-tapped back to its $12 base; every other number sits at base.
+    assert bets == {4: 10.0, 5: 10.0, 6: 12.0, 8: 12.0, 9: 10.0, 10: 10.0}
+
+
+def test_double_tap_resets_all_numbers_on_seven_out():
+    """A seven-out clears every number's progression back to its base."""
+    table = Table()
+    player = table.add_player(bankroll=2000.0, strategy=DoubleTap())
+    # pt 4; press the 6 once (-> $24); seven-out; new pt 6; realize fresh board.
+    table.fixed_run(
+        dice_outcomes=[(2, 2), (3, 3), (3, 4), (2, 4), (1, 1)], verbose=False
+    )
+    bets = {b.number: b.amount for b in player.bets}
+
+    # Board rebuilt entirely at base amounts (6 back to $12, not $24).
+    assert bets == {4: 10.0, 5: 10.0, 6: 12.0, 8: 12.0, 9: 10.0, 10: 10.0}

--- a/tests/integration/test_squeezeplay_integration.py
+++ b/tests/integration/test_squeezeplay_integration.py
@@ -1,0 +1,85 @@
+"""End-to-end scenarios for SqueezePlay / PlaceHitProgression.
+
+Each case runs a fixed sequence of dice through a real table and checks the
+resulting bankroll and open bets, exercising the stage advancement, the press and
+regress, the carry-across-made-points behavior, and the seven-out reset.
+"""
+
+import pytest
+
+from crapssim.strategy import PlaceHitProgression
+from crapssim.strategy.examples import SqueezePlay
+from crapssim.table import Table
+
+BUY_IN = 500.0
+
+
+def run(strategy, rolls):
+    """Run ``rolls`` through a fresh table and return (bankroll, sorted bets)."""
+    table = Table()
+    player = table.add_player(bankroll=BUY_IN, strategy=strategy)
+    table.fixed_run(dice_outcomes=rolls, verbose=False)
+    return player.bankroll, sorted(str(b) for b in player.bets)
+
+
+@pytest.mark.parametrize(
+    "rolls, expected_bankroll, expected_bets",
+    [
+        # Point 4 established, no numbers hit yet -> $66 inside working. (Bets for
+        # the point established on the LAST roll appear next roll, hence a trailing
+        # roll to realize the board.)
+        (
+            [(2, 2), (5, 6), (1, 3)],  # pt 4, come-out 11, pt 4 again
+            BUY_IN - 66.0,
+            ["$15 Place(5)", "$15 Place(9)", "$18 Place(6)", "$18 Place(8)"],
+        ),
+        # Three inside hits with an outside point (4) so hits never make the point:
+        # 5, 9, 6 -> board regresses to $64 across, then a seven-out clears it.
+        # Net: +21 +21 +28 - 64 = +6.
+        (
+            [(2, 2), (1, 4), (4, 5), (2, 4), (3, 4)],
+            BUY_IN + 6.0,
+            [],
+        ),
+        # Seven-out sweeps the initial $66 board and restarts the progression.
+        (
+            [(3, 3), (3, 4)],  # pt 6, then seven-out (nothing hit first)
+            BUY_IN - 66.0,  # the initial $66 inside is lost
+            [],
+        ),
+    ],
+)
+def test_squeezeplay_scenarios(rolls, expected_bankroll, expected_bets):
+    bankroll, bets = run(SqueezePlay(), rolls)
+    assert bankroll == expected_bankroll
+    assert bets == expected_bets
+
+
+def test_squeezeplay_carries_progression_across_made_point():
+    """A made point banks winnings and rebuilds at the same stage, not stage 0."""
+    # pt 6; hit the 8 (hit 1, adds 4 & 10); roll 6 -> Place(6) pays AND makes the
+    # point (hit 2); new point 4; a non-scoring 2 realizes the rebuilt 2-hit board
+    # ($88 inside + 4 & 10) instead of restarting at $66.
+    rolls = [(3, 3), (4, 4), (3, 3), (2, 2), (1, 1)]
+    _, bets = run(SqueezePlay(), rolls)
+    assert bets == [
+        "$10 Place(10)",
+        "$10 Place(4)",
+        "$20 Place(5)",
+        "$20 Place(9)",
+        "$24 Place(6)",
+        "$24 Place(8)",
+    ]
+
+
+def test_independent_progressions_press_separately():
+    """Two disjoint PlaceHitProgressions in an AggregateStrategy advance alone."""
+    six = PlaceHitProgression([{6: 12.0}, {6: 18.0}, {6: 24.0}])
+    eight = PlaceHitProgression([{8: 12.0}, {8: 18.0}, {8: 24.0}])
+    strategy = six + eight
+
+    # pt 4; 6 hits twice (press 6: 12 -> 18 -> 24), 8 never hits, trailing roll.
+    _, bets = run(strategy, [(2, 2), (3, 3), (2, 4), (1, 4)])
+
+    # The 6 pressed to $24 on its own hits; the untouched 8 stayed at $12.
+    assert bets == ["$12 Place(8)", "$24 Place(6)"]

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -34,6 +34,7 @@ from crapssim.strategy import (
 )
 from crapssim.strategy.examples import (
     DiceDoctor,
+    DoubleTap,
     HammerLock,
     Pass2Come,
     PassLinePlace68,
@@ -329,6 +330,42 @@ def test_squeeze_play_owns_all_place_numbers():
 
 def test_squeeze_play_repr():
     assert repr(SqueezePlay()) == "SqueezePlay()"
+
+
+# ── DoubleTap ─────────────────────────────────────────────────────────────────
+
+
+def test_double_tap_has_one_progression_per_place_number():
+    strategy = DoubleTap()
+    assert len(strategy.strategies) == 6
+    owned = {next(iter(s.numbers)) for s in strategy.strategies}
+    assert owned == {4, 5, 6, 8, 9, 10}
+    assert all(len(s.numbers) == 1 for s in strategy.strategies)
+
+
+def test_double_tap_six_eight_sequence():
+    strategy = DoubleTap()
+    six = next(s for s in strategy.strategies if s.numbers == frozenset({6}))
+    assert [stage[6] for stage in six.stages] == [12, 24, 48, 12, 24, 48, 12]
+
+
+def test_double_tap_outside_sequence():
+    strategy = DoubleTap()
+    five = next(s for s in strategy.strategies if s.numbers == frozenset({5}))
+    assert [stage[5] for stage in five.stages] == [10, 20, 40, 10, 20, 40, 10]
+
+
+def test_double_tap_scales_with_base_amount():
+    strategy = DoubleTap(base_amount=25)
+    six = next(s for s in strategy.strategies if s.numbers == frozenset({6}))
+    nine = next(s for s in strategy.strategies if s.numbers == frozenset({9}))
+    # 6/8 start near 7/6 * 25 = 29.17, rounded to the nearest $6 -> $30.
+    assert [stage[6] for stage in six.stages] == [30, 60, 120, 30, 60, 120, 30]
+    assert [stage[9] for stage in nine.stages] == [25, 50, 100, 25, 50, 100, 25]
+
+
+def test_double_tap_repr():
+    assert repr(DoubleTap()) == "DoubleTap(base_amount=10.0)"
 
 
 def test_aggregate_repr(aggregate_strategy):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -28,6 +28,7 @@ from crapssim.strategy import (
     AggregateStrategy,
     BetPlace,
     CountStrategy,
+    PlaceHitProgression,
     RemoveIfTrue,
     Strategy,
 )
@@ -41,6 +42,7 @@ from crapssim.strategy.examples import (
     Place682Come,
     PlaceInside,
     Risk12,
+    SqueezePlay,
 )
 from crapssim.strategy.odds import (
     ComeOddsMultiplier,
@@ -195,6 +197,138 @@ def test_aggregate_strategy_after_roll_skips_completed(aggregate_strategy, playe
 
     aggregate_strategy.strategies[0].after_roll.assert_not_called()
     aggregate_strategy.strategies[1].after_roll.assert_called_once_with(player)
+
+
+# ── PlaceHitProgression ───────────────────────────────────────────────────────
+
+
+def test_place_hit_progression_empty_stages_raises():
+    with pytest.raises(ValueError):
+        PlaceHitProgression([])
+
+
+def test_place_hit_progression_numbers_is_union_of_stages():
+    strategy = PlaceHitProgression([{5: 15, 9: 15}, {5: 15, 9: 15, 4: 10, 10: 10}])
+    assert strategy.numbers == frozenset({4, 5, 9, 10})
+
+
+def test_place_hit_progression_target_holds_last_stage():
+    strategy = PlaceHitProgression([{6: 12}, {6: 18}, {6: 24}])
+    strategy.hit_count = 99
+    assert strategy._target() == {6: 24}
+
+
+def test_place_hit_progression_counts_owned_hit(player):
+    strategy = PlaceHitProgression([{6: 12}, {6: 18}])
+    player.table.point.number = 4  # point on
+    player.table.dice.result = (2, 4)  # total 6, not a seven-out
+    bet = Place(6, 12)
+    bet.get_result = MagicMock(return_value=BetResult(14, True))
+    player.bets = [bet]
+
+    strategy.after_roll(player)
+
+    assert strategy.hit_count == 1
+
+
+def test_place_hit_progression_ignores_unowned_hit(player):
+    strategy = PlaceHitProgression([{6: 12}])  # owns only 6
+    player.table.point.number = 4
+    player.table.dice.result = (3, 5)  # total 8
+    winning_eight = Place(8, 12)
+    winning_eight.get_result = MagicMock(return_value=BetResult(14, True))
+    player.bets = [winning_eight]
+
+    strategy.after_roll(player)
+
+    assert strategy.hit_count == 0
+
+
+def test_place_hit_progression_seven_out_sets_flag(player):
+    strategy = PlaceHitProgression([{6: 12}])
+    player.table.point.number = 6  # point on
+    player.table.dice.result = (3, 4)  # seven-out
+
+    strategy.after_roll(player)
+
+    assert strategy._seven_out is True
+
+
+def test_place_hit_progression_seven_out_resets(player):
+    strategy = PlaceHitProgression([{6: 12}, {6: 18}])
+    strategy.hit_count = 1
+    strategy._seven_out = True
+    player.bets = [Place(6, 18)]
+
+    strategy.update_bets(player)
+
+    assert player.bets == []
+    assert strategy.hit_count == 0
+    assert strategy._seven_out is False
+
+
+def test_place_hit_progression_comeout_clears_but_preserves_progression(player):
+    strategy = PlaceHitProgression([{6: 12}, {6: 18}])
+    strategy.hit_count = 1
+    player.table.point.number = None  # come-out
+    player.bets = [Place(6, 18)]
+
+    strategy.update_bets(player)
+
+    assert player.bets == []
+    assert strategy.hit_count == 1  # progression preserved across the come-out
+
+
+def test_place_hit_progression_reconciles_to_current_stage(player):
+    strategy = PlaceHitProgression([{6: 12, 8: 12}, {6: 18, 8: 18}])
+    strategy.hit_count = 1
+    player.bankroll = float("inf")
+    player.table.point.number = 4  # point on
+    player.bets = []
+
+    strategy.update_bets(player)
+
+    assert Place(6, 18) in player.bets
+    assert Place(8, 18) in player.bets
+
+
+def test_place_hit_progression_leaves_unowned_bets_untouched(player):
+    strategy = PlaceHitProgression([{6: 12}])  # owns only 6
+    player.bankroll = float("inf")
+    player.table.point.number = 4
+    other = Place(8, 12)
+    player.bets = [other]
+
+    strategy.update_bets(player)
+
+    assert other in player.bets  # unowned bet is left alone
+    assert Place(6, 12) in player.bets
+
+
+def test_place_hit_progression_repr():
+    strategy = PlaceHitProgression([{6: 12.0}])
+    assert repr(strategy) == "PlaceHitProgression(stages=[{6: 12.0}])"
+
+
+# ── SqueezePlay ───────────────────────────────────────────────────────────────
+
+
+def test_squeeze_play_stage_boards():
+    strategy = SqueezePlay()
+    assert strategy.stages == [
+        {5: 15.0, 6: 18.0, 8: 18.0, 9: 15.0},
+        {5: 15.0, 6: 18.0, 8: 18.0, 9: 15.0, 4: 10.0, 10: 10.0},
+        {5: 20.0, 6: 24.0, 8: 24.0, 9: 20.0, 4: 10.0, 10: 10.0},
+        {4: 10.0, 5: 10.0, 6: 12.0, 8: 12.0, 9: 10.0, 10: 10.0},
+    ]
+
+
+def test_squeeze_play_owns_all_place_numbers():
+    assert SqueezePlay().numbers == frozenset({4, 5, 6, 8, 9, 10})
+
+
+def test_squeeze_play_repr():
+    assert repr(SqueezePlay()) == "SqueezePlay()"
 
 
 def test_aggregate_repr(aggregate_strategy):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -175,6 +175,28 @@ def test_aggregate_strategy_completed_calls_all_completed(aggregate_strategy, pl
     aggregate_strategy.strategies[1].completed.assert_called_once_with(player)
 
 
+def test_aggregate_strategy_calls_all_after_roll(aggregate_strategy, player):
+    aggregate_strategy.strategies[0].after_roll = MagicMock()
+    aggregate_strategy.strategies[1].after_roll = MagicMock()
+
+    aggregate_strategy.after_roll(player)
+
+    aggregate_strategy.strategies[0].after_roll.assert_called_once_with(player)
+    aggregate_strategy.strategies[1].after_roll.assert_called_once_with(player)
+
+
+def test_aggregate_strategy_after_roll_skips_completed(aggregate_strategy, player):
+    aggregate_strategy.strategies[0].completed = lambda p: True
+    aggregate_strategy.strategies[1].completed = lambda p: False
+    aggregate_strategy.strategies[0].after_roll = MagicMock()
+    aggregate_strategy.strategies[1].after_roll = MagicMock()
+
+    aggregate_strategy.after_roll(player)
+
+    aggregate_strategy.strategies[0].after_roll.assert_not_called()
+    aggregate_strategy.strategies[1].after_roll.assert_called_once_with(player)
+
+
 def test_aggregate_repr(aggregate_strategy):
     assert repr(aggregate_strategy) == "TestStrategy1() + TestStrategy2()"
 


### PR DESCRIPTION

Added `PlaceHitProgression` strategy tool: For strategies built from place bets that change after each hit in predictable stages. For example, start with $12 on 6, then if it hits, increase to $18, then press to $30 after the next hit. This works with sequences of place bets as well, changing the bets with a hit on any single place bet. Can be composed to handle progressions on independent numbers (e.g. 6 and 8 separately). 

Added `SqueezePlay` as a strategy example: $66 inside -> add 4/10 -> Press inside -> Regress to $64 across

Added `DoubleTap` as a strategy example: press each place number independently twice, before regressing down to the starting amount and continuing again. 

This surfaced an issue with AggregateStrategy. `AggregateStrategy` now forwards `after_roll` to its substrategies, so composed strategies that count wins or detect a seven-out in `after_roll` observe the roll

Fixed some mypy typing errors (mostly which have been around in the package for a while)