### PR TITLE
Fix/issue-80-working-bets: DC odds should be working during the come-out by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 * Support for Crapless craps via new `rules` module, with corresponding updates across table and bet from [@tyemerick88] in [#86]
-* Expanded the test suite with new unit and integration tests to improve coverage from [@tyemerick88] in [#86]
+* Expanded the test suite with new unit and integration tests to improve coverage from [@tyemerick88] in [#86], [#87]
 * `PlaceHitProgression` strategy tool: For strategies built from place bets that change after each hit in predictable stages from [@skent259] in [#87]
   * `SqueezePlay` strategy example: $66 inside -> add 4/10 -> Press inside -> Regress to $64 across
   * `DoubleTap` strategy example: presses each place number twice then regresses, with every number progressing independently on its own hits
 
+
+### Changed 
+
+* Bet behavior during comeout phase (working vs not) updated by [@tyemerick88] in [#88]
+  * `Buy`, `Lay`, and `Put` bets now have `always_working` argument
+  * `always_working` bet option can now also be None (inherits from new `TableSettings` policy)
+  * Add internal `_BoxNumberBet` to cover logic for `Place`, `Buy`, `Lay`, and `Put` bets
+* `Place` bets now default to staying on the table on a win ([#88])
+
 ### Fixed
 
 * `AggregateStrategy` now forwards `after_roll` to its substrategies, so composed strategies that count wins or detect a seven-out in `after_roll` observe the roll [#87]
+* DC bet odds are now working on the comeout by default ([#88], [#80])
+* `Place68PR` strategy now appropriately regresses after 2nd hit ([#88])
+* `WinProgression` can be aggregated with strategies that have other bet types ([#88]) 
+
 
 
 ## [0.4.0] - 2025-11-18
@@ -161,6 +174,8 @@ Initial version
 [#83]: https://github.com/skent259/crapssim/pull/71
 [#86]: https://github.com/skent259/crapssim/pull/86
 [#87]: https://github.com/skent259/crapssim/pull/87
+[#88]: https://github.com/skent259/crapssim/pull/88
 
 [#48]: https://github.com/skent259/crapssim/issues/48
 [#53]: https://github.com/skent259/crapssim/issues/53
+[#80]: https://github.com/skent259/crapssim/issues/80

--- a/crapssim/__init__.py
+++ b/crapssim/__init__.py
@@ -1,3 +1,5 @@
+"""Public package exports for crapssim."""
+
 __all__ = ["table", "dice", "strategy", "bet", "rules", "Table", "Player"]
 
 from crapssim.dice import Dice

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -916,8 +916,9 @@ class Place(_SimpleBet):
             return super().get_result(table)
 
         if table.dice.total == self.number:
-            # don't add the original bet amount back, since place bets are not returned on a win
-            result_amount = self.payout_ratio * self.amount
+            # BetResult.bankroll_change subtracts bet_amount for non-removing wins, so include
+            # principal here to yield only the place-bet profit while keeping the wager on layout.
+            result_amount = self.payout_ratio * self.amount + self.amount
             remove = False
         elif table.dice.total == 7:
             result_amount = -1 * self.amount

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -112,9 +112,44 @@ class BetResult:
     remove: bool
     """Flag indicating whether this bet result should be removed from table."""
     bet_amount: float = 0
-    """The monetary value of the original bet size. Needed only for bets that 
-    push and return the wager to the player. Default is zero for quick 
+    """The monetary value of the original bet size. Needed only for bets that
+    push and return the wager to the player. Default is zero for quick
     results that can define wins and losses by comparing against zero."""
+
+    @classmethod
+    def win(cls, *, profit: float, bet_amount: float, remove: bool) -> "BetResult":
+        """A winning bet.
+
+        Args:
+            profit: Winnings above the wager (payout only, principal excluded).
+            bet_amount: The original wager.
+            remove: Whether the wager comes off the table (True) or keeps
+                working (False). This flag alone decides whether the returned
+                principal is credited to the bankroll; see
+                :attr:`bankroll_change`.
+        """
+        return cls(amount=profit + bet_amount, remove=remove, bet_amount=bet_amount)
+
+    @classmethod
+    def lose(cls, *, cost: float, bet_amount: float) -> "BetResult":
+        """A losing bet, removed from the table.
+
+        Args:
+            cost: Amount lost. Equal to the wager for most bets, but may exceed
+                it when an upfront vig was paid.
+            bet_amount: The original wager.
+        """
+        return cls(amount=-cost, remove=True, bet_amount=bet_amount)
+
+    @classmethod
+    def push(cls, bet_amount: float) -> "BetResult":
+        """A tie: the wager is returned to the player and the bet removed."""
+        return cls(amount=bet_amount, remove=True, bet_amount=bet_amount)
+
+    @classmethod
+    def no_change(cls, bet_amount: float) -> "BetResult":
+        """No action this roll: the bet does nothing and stays on the table."""
+        return cls(amount=0, remove=False, bet_amount=bet_amount)
 
     @property
     def won(self) -> bool:
@@ -133,10 +168,15 @@ class BetResult:
 
     @property
     def bankroll_change(self) -> float:
-        """Calculates bankroll delta for this result.
+        """Cash credited to the bankroll for this result.
 
-        Results that keep a winning bet on the table should only credit net
-        profit, not returned principal.
+        The wager was already deducted when the bet was placed, so:
+
+        - loss or no-action (``amount <= 0``): nothing is credited.
+        - non-removing win: the wager stays working on the table, so only the
+          net profit is credited.
+        - removing win or push: the wager comes off the table, so the full
+          returned amount (principal plus any winnings) is credited.
         """
         if self.amount <= 0:
             return 0
@@ -290,35 +330,30 @@ class _WinningLosingNumbersBet(Bet, ABC):
         in a loss of the original bet amount. Otherwise the bet stays
         on the table.
         """
-        # When the point is off, some bets are configured to be "off" as well.
-        # In that case we must short-circuit before normal win/loss resolution so
-        # come-out 7/point hits/pushes are ignored until the bet is working again.
+        resolving_numbers = (
+            self.get_winning_numbers(table)
+            + self.get_losing_numbers(table)
+            + self.get_push_numbers(table)
+        )
         if (
             table.point.status == "Off"
             and not self.is_working_on_come_out(table)
-            and table.dice.total
-            in (
-                self.get_winning_numbers(table)
-                + self.get_losing_numbers(table)
-                + self.get_push_numbers(table)
-            )
+            and table.dice.total in resolving_numbers
         ):
-            return BetResult(amount=self.amount, remove=True, bet_amount=self.amount)
+            return BetResult.push(self.amount)
 
         if table.dice.total in self.get_winning_numbers(table):
-            result_amount = self.get_payout_ratio(table) * self.amount + self.amount
-            should_remove = True
+            return BetResult.win(
+                profit=self.get_payout_ratio(table) * self.amount,
+                bet_amount=self.amount,
+                remove=True,
+            )
         elif table.dice.total in self.get_losing_numbers(table):
-            result_amount = -1 * self.amount
-            should_remove = True
+            return BetResult.lose(cost=self.amount, bet_amount=self.amount)
         elif table.dice.total in self.get_push_numbers(table):
-            result_amount = self.amount
-            should_remove = True
+            return BetResult.push(self.amount)
         else:
-            result_amount = 0
-            should_remove = False
-
-        return BetResult(result_amount, should_remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     @abstractmethod
     def get_winning_numbers(self, table: Table) -> list[int]:
@@ -839,7 +874,7 @@ class Put(_SimpleBet):
             and not self.is_working_on_come_out(table)
             and table.dice.total in (self.number, 7)
         ):
-            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+            return BetResult.no_change(self.amount)
 
         return super().get_result(table)
 
@@ -928,25 +963,24 @@ class Place(_SimpleBet):
             and not self.is_working_on_come_out(table)
             and table.dice.total in (self.number, 7)
         ):
-            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+            return BetResult.no_change(self.amount)
 
         if _come_out_working_policy(table.settings) == "legacy":
             # legacy support, tons of bets integration tests rely on old behavior
             return super().get_result(table)
 
         if table.dice.total == self.number:
-            # BetResult.bankroll_change subtracts bet_amount for non-removing wins, so include
-            # principal here to yield only the place-bet profit while keeping the wager on layout.
-            result_amount = self.payout_ratio * self.amount + self.amount
-            remove = False
+            # Place wins leave the wager working on the table (remove=False), so
+            # only the profit is credited to the bankroll.
+            return BetResult.win(
+                profit=self.payout_ratio * self.amount,
+                bet_amount=self.amount,
+                remove=False,
+            )
         elif table.dice.total == 7:
-            result_amount = -1 * self.amount
-            remove = True
+            return BetResult.lose(cost=self.amount, bet_amount=self.amount)
         else:
-            result_amount = 0
-            remove = False
-
-        return BetResult(result_amount, remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     def is_working_on_come_out(self, table: Table) -> bool:
         if self.always_working is not None:
@@ -1050,20 +1084,17 @@ class Buy(_SimpleBet):
             and not self.is_working_on_come_out(table)
             and table.dice.total in (self.number, 7)
         ):
-            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+            return BetResult.no_change(self.amount)
 
         if table.dice.total == self.number:
-            result_amount = self.payout_ratio * self.amount + self.amount
+            profit = self.payout_ratio * self.amount
             if table.settings.get("vig_paid_on_win", True):
-                result_amount -= self.vig(table)
-            remove = True
+                profit -= self.vig(table)
+            return BetResult.win(profit=profit, bet_amount=self.amount, remove=True)
         elif table.dice.total == 7:
-            result_amount = -1 * self.cost(table)
-            remove = True
+            return BetResult.lose(cost=self.cost(table), bet_amount=self.amount)
         else:
-            result_amount = 0
-            remove = False
-        return BetResult(result_amount, remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     def is_allowed(self, player: "Player") -> bool:
         """Return whether this Buy bet number is legal and can be placed for
@@ -1154,20 +1185,17 @@ class Lay(_SimpleBet):
             and not self.is_working_on_come_out(table)
             and table.dice.total in (self.number, 7)
         ):
-            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+            return BetResult.no_change(self.amount)
 
         if table.dice.total == 7:
-            result_amount = self.payout_ratio * self.amount + self.amount
+            profit = self.payout_ratio * self.amount
             if table.settings.get("vig_paid_on_win", True):
-                result_amount -= self.vig(table)
-            remove = True
+                profit -= self.vig(table)
+            return BetResult.win(profit=profit, bet_amount=self.amount, remove=True)
         elif table.dice.total == self.number:
-            result_amount = -self.cost(table)
-            remove = True
+            return BetResult.lose(cost=self.cost(table), bet_amount=self.amount)
         else:
-            result_amount = 0
-            remove = False
-        return BetResult(result_amount, remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     def is_allowed(self, player: "Player") -> bool:
         """Return whether this Lay bet number is legal and can be placed for
@@ -1480,15 +1508,15 @@ class HardWay(Bet):
 
     def get_result(self, table: Table) -> BetResult:
         if table.dice.result == self.winning_result:
-            result_amount = self.payout_ratio * self.amount + self.amount
-            should_remove = True
+            return BetResult.win(
+                profit=self.payout_ratio * self.amount,
+                bet_amount=self.amount,
+                remove=True,
+            )
         elif table.dice.total in (7, self.number):
-            result_amount = -1 * self.amount
-            should_remove = True
+            return BetResult.lose(cost=self.amount, bet_amount=self.amount)
         else:
-            result_amount = 0
-            should_remove = False
-        return BetResult(result_amount, should_remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     @property
     def winning_result(self) -> tuple[int, int]:
@@ -1535,12 +1563,12 @@ class Hop(Bet):
 
     def get_result(self, table: Table) -> BetResult:
         if table.dice.result in self.winning_results:
-            result_amount = self.payout_ratio(table) * self.amount + self.amount
-            should_remove = True
-        else:
-            result_amount = -1 * self.amount
-            should_remove = True
-        return BetResult(result_amount, should_remove, self.amount)
+            return BetResult.win(
+                profit=self.payout_ratio(table) * self.amount,
+                bet_amount=self.amount,
+                remove=True,
+            )
+        return BetResult.lose(cost=self.amount, bet_amount=self.amount)
 
     @property
     def is_easy(self) -> bool:
@@ -1603,7 +1631,7 @@ class Fire(Bet):
     def get_result(self, table: Table) -> BetResult:
 
         if table.point.status == "Off":
-            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+            return BetResult.no_change(self.amount)
 
         if table.dice.total == table.point.number:
             self.points_made.add(table.point.number)
@@ -1613,15 +1641,16 @@ class Fire(Bet):
         n_points_made = len(self.points_made)
         ended = table.dice.total == 7 or len(self.points_made) == 6
 
-        if ended and n_points_made in table.settings["fire_payouts"]:
+        if not ended:
+            return BetResult.no_change(self.amount)
+        if n_points_made in table.settings["fire_payouts"]:
             payout_ratio = table.settings["fire_payouts"][n_points_made]
-            result_amount = payout_ratio * self.amount + self.amount
-        elif ended and n_points_made not in table.settings["fire_payouts"]:
-            result_amount = -1 * self.amount
-        else:
-            result_amount = 0
-
-        return BetResult(result_amount, remove=ended, bet_amount=self.amount)
+            return BetResult.win(
+                profit=payout_ratio * self.amount,
+                bet_amount=self.amount,
+                remove=True,
+            )
+        return BetResult.lose(cost=self.amount, bet_amount=self.amount)
 
     def is_removable(self, table: Table) -> bool:
         """Fire bet is removable only if there is a new shooter.
@@ -1660,16 +1689,15 @@ class _ATSBet(Bet):
 
         if self.numbers == list(self.rolled_numbers):
             payout_ratio = table.settings["ATS_payouts"][self.type]
-            result_amount = payout_ratio * self.amount + self.amount
-            should_remove = True
+            return BetResult.win(
+                profit=payout_ratio * self.amount,
+                bet_amount=self.amount,
+                remove=True,
+            )
         elif table.dice.total == 7:
-            result_amount = -1 * self.amount
-            should_remove = True
+            return BetResult.lose(cost=self.amount, bet_amount=self.amount)
         else:
-            result_amount = 0
-            should_remove = False
-
-        return BetResult(result_amount, should_remove, self.amount)
+            return BetResult.no_change(self.amount)
 
     def is_removable(self, table: Table) -> bool:
         """All/Tall/Small bets are removable only if the last roll was a 7

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -48,16 +48,6 @@ CLASSIC_POINTS = (4, 5, 6, 8, 9, 10)
 CRAPLESS_POINTS = (2, 3, 4, 5, 6, 8, 9, 10, 11, 12)
 
 
-def _come_out_working_policy(
-    settings: TableSettings,
-) -> Literal["legacy", "real_casino"]:
-    """Return the default working policy for bets when the point is off."""
-    policy = settings.get("come_out_working_policy", "legacy")
-    if policy not in {"legacy", "real_casino"}:
-        return "legacy"
-    return cast(Literal["legacy", "real_casino"], policy)
-
-
 class TableSettings(TypedDict, total=False):
     """Subset of table policy toggles referenced by bet logic."""
 
@@ -71,6 +61,19 @@ class TableSettings(TypedDict, total=False):
     vig_floor: float
     vig_paid_on_win: bool
     come_out_working_policy: Literal["legacy", "real_casino"]
+
+
+def _come_out_working_policy(
+    settings: TableSettings,
+) -> Literal["legacy", "real_casino"]:
+    """Return the default working policy for bets when the point is off."""
+
+    default_policy = "real_casino"
+    policy = settings.get("come_out_working_policy", default_policy)
+
+    if policy not in {"legacy", "real_casino"}:
+        return default_policy
+    return cast(Literal["legacy", "real_casino"], policy)
 
 
 class Table(Protocol):
@@ -761,9 +764,11 @@ class Odds(_WinningLosingNumbersBet):
         return new_bet
 
     def _get_always_working_repr(self) -> str:
-        """Since the default is false, only need to print when True"""
+        """Since the default is None, only need to print when explicitly set."""
         return (
-            f", always_working={self.always_working})" if self.always_working else ")"
+            f", always_working={self.always_working})"
+            if self.always_working is not None
+            else ")"
         )
 
     @property

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -364,10 +364,6 @@ class _WinningLosingNumbersBet(Bet, ABC):
         """Returns the push numbers, based on table features and ruleset."""
         return []
 
-    def is_working_on_come_out(self, table: Table) -> bool:
-        """Return whether this bet should resolve while the point is off."""
-        return True
-
     @abstractmethod
     def get_payout_ratio(self, table: Table) -> float:
         """Returns the payout ratio (X to 1), based on table features."""
@@ -536,9 +532,6 @@ class Come(_WinningLosingNumbersBet):
         new_bet = self.__class__(self.amount, number=None)
         return new_bet
 
-    def is_working_on_come_out(self, table: Table) -> bool:
-        return True
-
     @property
     def _placed_key(self) -> Hashable:
         return type(self), self.number
@@ -658,9 +651,6 @@ class DontCome(_WinningLosingNumbersBet):
         new_bet = self.__class__(self.amount, number=None)
         return new_bet
 
-    def is_working_on_come_out(self, table: Table) -> bool:
-        return True
-
     @property
     def _placed_key(self) -> Hashable:
         return type(self), self.number
@@ -724,7 +714,12 @@ class Odds(_WinningLosingNumbersBet):
         """Whether this odds bet follows dont-pass/dont-come logic."""
         return issubclass(self.base_type, (DontPass, DontCome))
 
-    def is_working_on_come_out(self, table: Table) -> bool:
+    def is_working_on_come_out(self) -> bool:
+        """Whether the bet resolves while the point is off.
+
+        Defaults to false for all base_type bets except DontCome, but an explicit
+        ``always_working`` set on the bet overrides it.
+        """
         if self.always_working is not None:
             return self.always_working
         return issubclass(self.base_type, DontCome)
@@ -732,7 +727,7 @@ class Odds(_WinningLosingNumbersBet):
     def get_result(self, table: Table) -> BetResult:
         if (
             table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
+            and not self.is_working_on_come_out()
             and table.dice.total
             in self.get_winning_numbers(table) + self.get_losing_numbers(table)
         ):

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -51,6 +51,16 @@ def _is_number_allowed_by_rules(number: int, rules: Rules) -> bool:
     return number in rules.valid_point_bet_numbers()
 
 
+def _come_out_working_policy(
+    settings: TableSettings,
+) -> Literal["legacy", "real_casino"]:
+    """Return the default working policy for bets when the point is off."""
+    policy = settings.get("come_out_working_policy", "legacy")
+    if policy not in {"legacy", "real_casino"}:
+        return "legacy"
+    return cast(Literal["legacy", "real_casino"], policy)
+
+
 class TableSettings(TypedDict, total=False):
     """Subset of table policy toggles referenced by bet logic."""
 
@@ -116,8 +126,16 @@ class BetResult:
 
     @property
     def bankroll_change(self) -> float:
-        """Calculates the change to the bankroll (amount if bet won, zero otherwise)."""
-        return self.amount if self.amount > 0 else 0
+        """Calculates bankroll delta for this result.
+
+        Results that keep a winning bet on the table should only credit net
+        profit, not returned principal.
+        """
+        if self.amount <= 0:
+            return 0
+        if not self.remove:
+            return self.amount - self.bet_amount
+        return self.amount
 
 
 class _MetaBetABC(ABCMeta):
@@ -265,6 +283,21 @@ class _WinningLosingNumbersBet(Bet, ABC):
         in a loss of the original bet amount. Otherwise the bet stays
         on the table.
         """
+        # When the point is off, some bets are configured to be "off" as well.
+        # In that case we must short-circuit before normal win/loss resolution so
+        # come-out 7/point hits/pushes are ignored until the bet is working again.
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total
+            in (
+                self.get_winning_numbers(table)
+                + self.get_losing_numbers(table)
+                + self.get_push_numbers(table)
+            )
+        ):
+            return BetResult(amount=self.amount, remove=True, bet_amount=self.amount)
+
         if table.dice.total in self.get_winning_numbers(table):
             result_amount = self.get_payout_ratio(table) * self.amount + self.amount
             should_remove = True
@@ -293,6 +326,10 @@ class _WinningLosingNumbersBet(Bet, ABC):
     def get_push_numbers(self, table: Table) -> list[int]:
         """Returns the push numbers, based on table features and ruleset."""
         return []
+
+    def is_working_on_come_out(self, table: Table) -> bool:
+        """Return whether this bet should resolve while the point is off."""
+        return True
 
     @abstractmethod
     def get_payout_ratio(self, table: Table) -> float:
@@ -474,6 +511,9 @@ class Come(_WinningLosingNumbersBet):
         new_bet = self.__class__(self.amount, number=None)
         return new_bet
 
+    def is_working_on_come_out(self, table: Table) -> bool:
+        return True
+
     @property
     def _placed_key(self) -> Hashable:
         return type(self), self.number
@@ -593,6 +633,9 @@ class DontCome(_WinningLosingNumbersBet):
         new_bet = self.__class__(self.amount, number=None)
         return new_bet
 
+    def is_working_on_come_out(self, table: Table) -> bool:
+        return True
+
     @property
     def _placed_key(self) -> Hashable:
         return type(self), self.number
@@ -623,7 +666,7 @@ class Odds(_WinningLosingNumbersBet):
         base_type: type["PassLine | DontPass | Come | DontCome | Put"],
         number: int,
         amount: float,
-        always_working: bool = False,
+        always_working: bool | None = None,
     ):
         super().__init__(amount)
         self.base_type = base_type
@@ -638,19 +681,10 @@ class Odds(_WinningLosingNumbersBet):
     def dark_side(self) -> bool:
         return issubclass(self.base_type, (DontPass, DontCome))
 
-    def get_result(self, table: Table) -> BetResult:
-
-        if table.point.status == "Off" and not self.always_working:
-
-            if table.dice.total in (
-                self.get_losing_numbers(table) + self.get_winning_numbers(table)
-            ):
-                # Bet "pushes" and returns to the player
-                return BetResult(
-                    amount=self.amount, remove=True, bet_amount=self.amount
-                )
-
-        return super().get_result(table)
+    def is_working_on_come_out(self, table: Table) -> bool:
+        if self.always_working is not None:
+            return self.always_working
+        return issubclass(self.base_type, DontCome)
 
     def get_winning_numbers(self, table: Table) -> list[int]:
         if self.light_side:
@@ -763,7 +797,12 @@ class Put(_SimpleBet):
 
     losing_numbers: list[int] = [7]
 
-    def __init__(self, number: int, amount: SupportsFloat) -> None:
+    def __init__(
+        self,
+        number: int,
+        amount: SupportsFloat,
+        always_working: bool | None = None,
+    ) -> None:
         # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
         if number not in CRAPLESS_POINTS:
             raise ValueError(f"Invalid {self.__class__} number: {number}")
@@ -771,6 +810,7 @@ class Put(_SimpleBet):
         self.number = number
         self.winning_numbers = [number]
         self.payout_ratio = 1.0
+        self.always_working = always_working
 
     def is_allowed(self, player: "Player") -> bool:
         """Return whether this Put bet number is legal and can be placed
@@ -785,7 +825,26 @@ class Put(_SimpleBet):
         )
 
     def copy(self) -> "Put":
-        return self.__class__(self.number, self.amount)
+        return self.__class__(
+            self.number,
+            self.amount,
+            always_working=self.always_working,
+        )
+
+    def get_result(self, table: "Table") -> BetResult:
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total in (self.number, 7)
+        ):
+            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+
+        return super().get_result(table)
+
+    def is_working_on_come_out(self, table: Table) -> bool:
+        if self.always_working is not None:
+            return self.always_working
+        return _come_out_working_policy(table.settings) == "legacy"
 
     @property
     def _placed_key(self) -> Hashable:
@@ -827,7 +886,12 @@ class Place(_SimpleBet):
       9 to 5 on (4, 10), 7 to 5 on (5, 9), and 7 to 6 on (6, 8)."""
     losing_numbers: list[int] = [7]
 
-    def __init__(self, number: int, amount: SupportsFloat):
+    def __init__(
+        self,
+        number: int,
+        amount: SupportsFloat,
+        always_working: bool | None = None,
+    ):
         # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
         if number not in CRAPLESS_POINTS:
             raise ValueError(f"Invalid {self.__class__} number: {number}")
@@ -836,6 +900,7 @@ class Place(_SimpleBet):
         """The placed number, which determines payout ratio"""
         self.payout_ratio = self.payout_ratios[number]
         self.winning_numbers = [number]
+        self.always_working = always_working
 
     def is_allowed(self, player: "Player") -> bool:
         """Return whether this Place bet number is legal and can be placed
@@ -848,8 +913,42 @@ class Place(_SimpleBet):
 
     def copy(self) -> "Bet":
         """Create a fresh copy of this bet"""
-        new_bet = self.__class__(self.number, self.amount)
+        new_bet = self.__class__(
+            self.number,
+            self.amount,
+            always_working=self.always_working,
+        )
         return new_bet
+
+    def get_result(self, table: "Table") -> BetResult:
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total in (self.number, 7)
+        ):
+            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+
+        if _come_out_working_policy(table.settings) == "legacy":
+            # legacy support, tons of bets integration tests rely on old behavior
+            return super().get_result(table)
+
+        if table.dice.total == self.number:
+            # don't add the original bet amount back, since place bets are not returned on a win
+            result_amount = self.payout_ratio * self.amount
+            remove = False
+        elif table.dice.total == 7:
+            result_amount = -1 * self.amount
+            remove = True
+        else:
+            result_amount = 0
+            remove = False
+
+        return BetResult(result_amount, remove, self.amount)
+
+    def is_working_on_come_out(self, table: Table) -> bool:
+        if self.always_working is not None:
+            return self.always_working
+        return _come_out_working_policy(table.settings) == "legacy"
 
     @property
     def _placed_key(self) -> Hashable:
@@ -916,7 +1015,12 @@ class Buy(_SimpleBet):
     }
     losing_numbers: list[int] = [7]
 
-    def __init__(self, number: int, amount: SupportsFloat) -> None:
+    def __init__(
+        self,
+        number: int,
+        amount: SupportsFloat,
+        always_working: bool | None = None,
+    ) -> None:
         # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
         if number not in CRAPLESS_POINTS:
             raise ValueError(f"Invalid {self.__class__} number: {number}")
@@ -924,6 +1028,7 @@ class Buy(_SimpleBet):
         self.number = number
         self.payout_ratio = self.true_odds[number]
         self.winning_numbers = [number]
+        self.always_working = always_working
         """Base amount that determines true-odds payouts."""
 
     def vig(self, table: "Table") -> float:
@@ -936,13 +1041,20 @@ class Buy(_SimpleBet):
         return self.amount + self.vig(table)
 
     def get_result(self, table: "Table") -> BetResult:
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total in (self.number, 7)
+        ):
+            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+
         if table.dice.total == self.number:
             result_amount = self.payout_ratio * self.amount + self.amount
             if table.settings.get("vig_paid_on_win", True):
                 result_amount -= self.vig(table)
             remove = True
         elif table.dice.total == 7:
-            result_amount = -self.cost(table)
+            result_amount = -1 * self.cost(table)
             remove = True
         else:
             result_amount = 0
@@ -959,8 +1071,17 @@ class Buy(_SimpleBet):
         return _is_number_allowed_by_rules(self.number, player.table.rules)
 
     def copy(self) -> "Buy":
-        new_bet = self.__class__(self.number, self.amount)
+        new_bet = self.__class__(
+            self.number,
+            self.amount,
+            always_working=self.always_working,
+        )
         return new_bet
+
+    def is_working_on_come_out(self, table: Table) -> bool:
+        if self.always_working is not None:
+            return self.always_working
+        return _come_out_working_policy(table.settings) == "legacy"
 
     @property
     def _placed_key(self) -> Hashable:
@@ -996,7 +1117,12 @@ class Lay(_SimpleBet):
     }
     winning_numbers: list[int] = [7]
 
-    def __init__(self, number: int, amount: SupportsFloat) -> None:
+    def __init__(
+        self,
+        number: int,
+        amount: SupportsFloat,
+        always_working: bool | None = None,
+    ) -> None:
         # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
         if number not in CRAPLESS_POINTS:
             raise ValueError(f"Invalid {self.__class__} number: {number}")
@@ -1004,6 +1130,7 @@ class Lay(_SimpleBet):
         self.number = number
         self.payout_ratio = self.true_odds[number]
         self.losing_numbers = [number]
+        self.always_working = always_working
         """Base amount risked against the box number."""
 
     def vig(self, table: "Table") -> float:
@@ -1017,6 +1144,13 @@ class Lay(_SimpleBet):
         return self.amount + self.vig(table)
 
     def get_result(self, table: "Table") -> BetResult:
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total in (self.number, 7)
+        ):
+            return BetResult(amount=0, remove=False, bet_amount=self.amount)
+
         if table.dice.total == 7:
             result_amount = self.payout_ratio * self.amount + self.amount
             if table.settings.get("vig_paid_on_win", True):
@@ -1040,8 +1174,17 @@ class Lay(_SimpleBet):
         return _is_number_allowed_by_rules(self.number, player.table.rules)
 
     def copy(self) -> "Lay":
-        new_bet = self.__class__(self.number, self.amount)
+        new_bet = self.__class__(
+            self.number,
+            self.amount,
+            always_working=self.always_working,
+        )
         return new_bet
+
+    def is_working_on_come_out(self, table: Table) -> bool:
+        if self.always_working is not None:
+            return self.always_working
+        return _come_out_working_policy(table.settings) == "legacy"
 
     @property
     def _placed_key(self) -> Hashable:

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -1,3 +1,5 @@
+"""Bet models and payout logic for the craps simulation engine."""
+
 import copy
 import math
 from abc import ABC, ABCMeta, abstractmethod
@@ -68,9 +70,12 @@ class TableSettings(TypedDict, total=False):
     vig_rounding: Literal["none", "ceil_dollar", "nearest_dollar"]
     vig_floor: float
     vig_paid_on_win: bool
+    come_out_working_policy: Literal["legacy", "real_casino"]
 
 
 class Table(Protocol):
+    """Table data required by bet implementations."""
+
     dice: Dice
     point: Point
     settings: TableSettings
@@ -78,11 +83,15 @@ class Table(Protocol):
 
 
 class Player(Protocol):
+    """Player data required by bet implementations."""
+
     table: Table
     bets: list["Bet"]
 
     @property
-    def bankroll(self) -> float: ...
+    def bankroll(self) -> float:
+        """Current bankroll available for placing bets."""
+        ...
 
 
 @dataclass(slots=True, frozen=True)
@@ -367,9 +376,10 @@ class PassLine(_WinningLosingNumbersBet):
     """
     Pass Line bet in craps.
 
-    A bet where the player wins if the first roll is a come-out winner for the active ruleset,
-    loses if the first roll is a come-out loser for the active ruleset, and establishes a point number
-    for subsequent rolls. Once a point is set, the player wins by rolling
+    A bet where the player wins if the first roll is a come-out winner for
+    the active ruleset, loses if the first roll is a come-out loser for the
+    active ruleset, and establishes a point number for subsequent rolls.
+    Once a point is set, the player wins by rolling
     the point number again before rolling a 7. Pays 1 to 1.
     """
 
@@ -657,10 +667,12 @@ class Odds(_WinningLosingNumbersBet):
 
     @property
     def light_side(self) -> bool:
+        """Whether this odds bet follows pass/come-style winning logic."""
         return issubclass(self.base_type, (PassLine, Come, Put))
 
     @property
     def dark_side(self) -> bool:
+        """Whether this odds bet follows dont-pass/dont-come logic."""
         return issubclass(self.base_type, (DontPass, DontCome))
 
     def is_working_on_come_out(self, table: Table) -> bool:
@@ -722,6 +734,7 @@ class Odds(_WinningLosingNumbersBet):
         return allowed
 
     def get_max_odds(self, table: Table) -> float:
+        """Return table-specific maximum odds multiple for this point."""
         if self.light_side:
             return table.settings["max_odds"][self.number]
         elif self.dark_side:
@@ -729,7 +742,8 @@ class Odds(_WinningLosingNumbersBet):
         else:
             raise NotImplementedError(f"Unsupported odds base type: {self.base_type}")
 
-    def base_amount(self, player: Player):
+    def base_amount(self, player: Player) -> float:
+        """Return total base-bet amount this odds bet is attached to."""
         base_bets = [
             x
             for x in player.bets
@@ -1016,6 +1030,7 @@ class Buy(_SimpleBet):
         """Base amount that determines true-odds payouts."""
 
     def vig(self, table: "Table") -> float:
+        """Compute buy-bet commission based on table vig policy."""
         rounding, floor = _vig_policy(table.settings)
         return _compute_vig(self.amount, rounding=rounding, floor=floor)
 
@@ -1118,6 +1133,7 @@ class Lay(_SimpleBet):
         """Base amount risked against the box number."""
 
     def vig(self, table: "Table") -> float:
+        """Compute lay-bet commission based on potential gross win."""
         rounding, floor = _vig_policy(table.settings)
         gross_win = self.amount * self.payout_ratio
         return _compute_vig(gross_win, rounding=rounding, floor=floor)
@@ -1181,7 +1197,7 @@ class Lay(_SimpleBet):
         return f"{super().__str__()}({self.number})"
 
 
-# _WinningLosingNumbersBets with variable payouts -----------------------------------------------------------------
+# _WinningLosingNumbersBets with variable payouts ------------------------------------------------
 
 
 class Field(_WinningLosingNumbersBet):
@@ -1523,16 +1539,19 @@ class Hop(Bet):
 
     @property
     def is_easy(self) -> bool:
+        """Whether this hop result uses two different dice faces."""
         return self.result[0] != self.result[1]
 
     @property
     def winning_results(self) -> list[tuple[int, int]]:
+        """All dice orderings that qualify this hop bet as a winner."""
         if self.is_easy:
             return [self.result, self.result[::-1]]
         else:
             return [self.result]
 
     def payout_ratio(self, table: Table) -> int:
+        """Return table-configured payout multiple for this hop type."""
         payout_type = "easy" if self.is_easy else "hard"
         return table.settings["hop_payouts"][payout_type]
 

--- a/crapssim/bet.py
+++ b/crapssim/bet.py
@@ -15,6 +15,7 @@ __all__ = [
     "Bet",
     "_WinningLosingNumbersBet",
     "_SimpleBet",
+    "_BoxNumberBet",
     "PassLine",
     "Come",
     "DontPass",
@@ -329,28 +330,22 @@ class _WinningLosingNumbersBet(Bet, ABC):
         happen when dice total is in the losing numbers, which result
         in a loss of the original bet amount. Otherwise the bet stays
         on the table.
-        """
-        resolving_numbers = (
-            self.get_winning_numbers(table)
-            + self.get_losing_numbers(table)
-            + self.get_push_numbers(table)
-        )
-        if (
-            table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
-            and table.dice.total in resolving_numbers
-        ):
-            return BetResult.push(self.amount)
 
-        if table.dice.total in self.get_winning_numbers(table):
+        This is the hot path of the simulator: it runs for every bet on
+        every roll, so it deliberately avoids come-out ("working") handling.
+        Bets that can be off on the come-out (Odds, Place/Buy/Lay/Put) apply
+        that guard in their own ``get_result`` before delegating here.
+        """
+        total = table.dice.total
+        if total in self.get_winning_numbers(table):
             return BetResult.win(
                 profit=self.get_payout_ratio(table) * self.amount,
                 bet_amount=self.amount,
                 remove=True,
             )
-        elif table.dice.total in self.get_losing_numbers(table):
+        elif total in self.get_losing_numbers(table):
             return BetResult.lose(cost=self.amount, bet_amount=self.amount)
-        elif table.dice.total in self.get_push_numbers(table):
+        elif total in self.get_push_numbers(table):
             return BetResult.push(self.amount)
         else:
             return BetResult.no_change(self.amount)
@@ -691,6 +686,22 @@ class Odds(_WinningLosingNumbersBet):
     or "dark side" (Don't Pass/Don't Come) bet.
     """
 
+    light_ratios = {
+        2: 6,
+        3: 3,
+        4: 2,
+        5: 3 / 2,
+        6: 6 / 5,
+        8: 6 / 5,
+        9: 3 / 2,
+        10: 2,
+        11: 3,
+        12: 6,
+    }
+    """True-odds payouts (X to 1) for light-side (Pass/Come/Put) odds."""
+    dark_ratios = {n: 1 / x for n, x in light_ratios.items()}
+    """True-odds payouts (X to 1) for dark-side (Don't Pass/Don't Come) odds."""
+
     def __init__(
         self,
         base_type: type["PassLine | DontPass | Come | DontCome | Put"],
@@ -718,6 +729,18 @@ class Odds(_WinningLosingNumbersBet):
             return self.always_working
         return issubclass(self.base_type, DontCome)
 
+    def get_result(self, table: Table) -> BetResult:
+        if (
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total
+            in self.get_winning_numbers(table) + self.get_losing_numbers(table)
+        ):
+            # Odds come down with their parent bet when the point is off and the
+            # base bet resolves, so the wager is returned to the player.
+            return BetResult.push(self.amount)
+        return super().get_result(table)
+
     def get_winning_numbers(self, table: Table) -> list[int]:
         if self.light_side:
             return [self.number]
@@ -735,24 +758,10 @@ class Odds(_WinningLosingNumbersBet):
             raise NotImplementedError(f"Unsupported odds base type: {self.base_type}")
 
     def get_payout_ratio(self, table: Table) -> float:
-        light_ratios = {
-            2: 6,
-            3: 3,
-            4: 2,
-            5: 3 / 2,
-            6: 6 / 5,
-            8: 6 / 5,
-            9: 3 / 2,
-            10: 2,
-            11: 3,
-            12: 6,
-        }
-        dark_ratios = {n: 1 / x for n, x in light_ratios.items()}
-
         if self.light_side:
-            return light_ratios[self.number]
+            return self.light_ratios[self.number]
         elif self.dark_side:
-            return dark_ratios[self.number]
+            return self.dark_ratios[self.number]
         else:
             raise NotImplementedError(f"Unsupported odds base type: {self.base_type}")
 
@@ -828,10 +837,16 @@ class Odds(_WinningLosingNumbersBet):
             raise NotImplementedError(f"Unsupported odds base type: {self.base_type}")
 
 
-class Put(_SimpleBet):
-    """Flat line bet on a box number; point must be ON and odds obey table policy."""
+# Box-number bets (Place / Buy / Lay / Put) ----------------------------------
 
-    losing_numbers: list[int] = [7]
+
+class _BoxNumberBet(_SimpleBet, ABC):
+    """Shared logic for single box-number bets (Place, Buy, Lay, Put).
+
+    Each is a wager on a box number (or against it, for Lay) that may be
+    working or off on the come-out, controlled by the table's come-out working
+    policy or an explicit ``always_working`` override on the bet.
+    """
 
     def __init__(
         self,
@@ -839,53 +854,77 @@ class Put(_SimpleBet):
         amount: SupportsFloat,
         always_working: bool | None = None,
     ) -> None:
-        # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
+        # Allow all crapless points on init, but only allow the bet for extremes
+        # in CraplessRules (enforced by is_allowed).
         if number not in CRAPLESS_POINTS:
             raise ValueError(f"Invalid {self.__class__} number: {number}")
         super().__init__(amount)
         self.number = number
-        self.winning_numbers = [number]
-        self.payout_ratio = 1.0
         self.always_working = always_working
+        self._set_payout()
+
+    @abstractmethod
+    def _set_payout(self) -> None:
+        """Set ``payout_ratio`` and the number-based winning/losing numbers."""
 
     def is_allowed(self, player: "Player") -> bool:
-        """Return whether this Put bet number is legal and can be placed
-        for the current table state.
+        """Return whether this bet's number is valid for the active ruleset."""
+        return self.number in player.table.rules.point_numbers()
 
-        Returns:
-            bool: True when the point is on and this bet number is valid
-            for the active ruleset.
+    def is_working_on_come_out(self, table: Table) -> bool:
+        """Whether the bet resolves while the point is off.
+
+        Defaults to the table's come-out working policy, but an explicit
+        ``always_working`` set on the bet overrides it.
         """
+        if self.always_working is not None:
+            return self.always_working
+        return _come_out_working_policy(table.settings) == "legacy"
+
+    def _off_come_out(self, table: Table) -> bool:
+        """True when the point is off and the bet is not working, so a roll of
+        its number or 7 leaves it inactive instead of resolving."""
         return (
-            player.table.point.status == "On"
-            and self.number in player.table.rules.point_numbers()
+            table.point.status == "Off"
+            and not self.is_working_on_come_out(table)
+            and table.dice.total in (self.number, 7)
         )
 
-    def copy(self) -> "Put":
+    def copy(self) -> "Bet":
+        """Create a fresh copy of this bet."""
         return self.__class__(
             self.number,
             self.amount,
             always_working=self.always_working,
         )
 
-    def get_result(self, table: "Table") -> BetResult:
-        if (
-            table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
-            and table.dice.total in (self.number, 7)
-        ):
-            return BetResult.no_change(self.amount)
-
-        return super().get_result(table)
-
-    def is_working_on_come_out(self, table: Table) -> bool:
-        if self.always_working is not None:
-            return self.always_working
-        return _come_out_working_policy(table.settings) == "legacy"
-
     @property
     def _placed_key(self) -> Hashable:
         return type(self), self.number
+
+
+class Put(_BoxNumberBet):
+    """Flat line bet on a box number; point must be ON and odds obey table policy."""
+
+    losing_numbers: list[int] = [7]
+
+    def _set_payout(self) -> None:
+        self.winning_numbers = [self.number]
+        self.payout_ratio = 1.0
+
+    def is_allowed(self, player: "Player") -> bool:
+        """Return whether this Put bet is legal: the point must be on and the
+        number valid for the active ruleset.
+        """
+        return (
+            player.table.point.status == "On"
+            and self.number in player.table.rules.point_numbers()
+        )
+
+    def get_result(self, table: "Table") -> BetResult:
+        if self._off_come_out(table):
+            return BetResult.no_change(self.amount)
+        return super().get_result(table)
 
     def __repr__(self) -> str:
         return f"Put({self.number}, amount={self.amount})"
@@ -897,7 +936,7 @@ class Put(_SimpleBet):
 # Place bets ------------------------------------------------------------------
 
 
-class Place(_SimpleBet):
+class Place(_BoxNumberBet):
     """
     A bet on a specific number being rolled before a 7.
     Each number has a different payout ratio reflecting its probability of being rolled.
@@ -923,46 +962,12 @@ class Place(_SimpleBet):
       9 to 5 on (4, 10), 7 to 5 on (5, 9), and 7 to 6 on (6, 8)."""
     losing_numbers: list[int] = [7]
 
-    def __init__(
-        self,
-        number: int,
-        amount: SupportsFloat,
-        always_working: bool | None = None,
-    ):
-        # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
-        if number not in CRAPLESS_POINTS:
-            raise ValueError(f"Invalid {self.__class__} number: {number}")
-        super().__init__(amount)
-        self.number = number
-        """The placed number, which determines payout ratio"""
-        self.payout_ratio = self.payout_ratios[number]
-        self.winning_numbers = [number]
-        self.always_working = always_working
-
-    def is_allowed(self, player: "Player") -> bool:
-        """Return whether this Place bet number is legal and can be placed
-        for the current table state.
-
-        Returns:
-            bool: True when this bet number is valid for the active ruleset.
-        """
-        return self.number in player.table.rules.point_numbers()
-
-    def copy(self) -> "Bet":
-        """Create a fresh copy of this bet"""
-        new_bet = self.__class__(
-            self.number,
-            self.amount,
-            always_working=self.always_working,
-        )
-        return new_bet
+    def _set_payout(self) -> None:
+        self.winning_numbers = [self.number]
+        self.payout_ratio = self.payout_ratios[self.number]
 
     def get_result(self, table: "Table") -> BetResult:
-        if (
-            table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
-            and table.dice.total in (self.number, 7)
-        ):
+        if self._off_come_out(table):
             return BetResult.no_change(self.amount)
 
         if _come_out_working_policy(table.settings) == "legacy":
@@ -981,15 +986,6 @@ class Place(_SimpleBet):
             return BetResult.lose(cost=self.amount, bet_amount=self.amount)
         else:
             return BetResult.no_change(self.amount)
-
-    def is_working_on_come_out(self, table: Table) -> bool:
-        if self.always_working is not None:
-            return self.always_working
-        return _come_out_working_policy(table.settings) == "legacy"
-
-    @property
-    def _placed_key(self) -> Hashable:
-        return type(self), self.number
 
     def __repr__(self) -> str:
         return f"Place({self.winning_numbers[0]}, amount={self.amount})"
@@ -1032,7 +1028,7 @@ def _vig_policy(
     )
 
 
-class Buy(_SimpleBet):
+class Buy(_BoxNumberBet):
     """True-odds bet on 2/3/4/5/6/8/9/10/11/12 that charges vig per table policy.
 
     Vig (commission) may be taken on the win or upfront based on ``vig_paid_on_win``.
@@ -1052,21 +1048,9 @@ class Buy(_SimpleBet):
     }
     losing_numbers: list[int] = [7]
 
-    def __init__(
-        self,
-        number: int,
-        amount: SupportsFloat,
-        always_working: bool | None = None,
-    ) -> None:
-        # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
-        if number not in CRAPLESS_POINTS:
-            raise ValueError(f"Invalid {self.__class__} number: {number}")
-        super().__init__(amount)
-        self.number = number
-        self.payout_ratio = self.true_odds[number]
-        self.winning_numbers = [number]
-        self.always_working = always_working
-        """Base amount that determines true-odds payouts."""
+    def _set_payout(self) -> None:
+        self.winning_numbers = [self.number]
+        self.payout_ratio = self.true_odds[self.number]
 
     def vig(self, table: "Table") -> float:
         """Compute buy-bet commission based on table vig policy."""
@@ -1079,11 +1063,7 @@ class Buy(_SimpleBet):
         return self.amount + self.vig(table)
 
     def get_result(self, table: "Table") -> BetResult:
-        if (
-            table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
-            and table.dice.total in (self.number, 7)
-        ):
+        if self._off_come_out(table):
             return BetResult.no_change(self.amount)
 
         if table.dice.total == self.number:
@@ -1096,32 +1076,6 @@ class Buy(_SimpleBet):
         else:
             return BetResult.no_change(self.amount)
 
-    def is_allowed(self, player: "Player") -> bool:
-        """Return whether this Buy bet number is legal and can be placed for
-        the current table state.
-
-        Returns:
-            bool: True when this number is allowed by the active ruleset.
-        """
-        return self.number in player.table.rules.point_numbers()
-
-    def copy(self) -> "Buy":
-        new_bet = self.__class__(
-            self.number,
-            self.amount,
-            always_working=self.always_working,
-        )
-        return new_bet
-
-    def is_working_on_come_out(self, table: Table) -> bool:
-        if self.always_working is not None:
-            return self.always_working
-        return _come_out_working_policy(table.settings) == "legacy"
-
-    @property
-    def _placed_key(self) -> Hashable:
-        return type(self), self.number
-
     def __repr__(self) -> str:
         return f"Buy({self.number}, amount={self.amount})"
 
@@ -1129,7 +1083,7 @@ class Buy(_SimpleBet):
         return f"{super().__str__()}({self.number})"
 
 
-class Lay(_SimpleBet):
+class Lay(_BoxNumberBet):
     """True-odds bet against 2/3/4/5/6/8/9/10/11/12, paying if 7 arrives first.
 
     Commission may be taken on the win or upfront based on ``vig_paid_on_win``.
@@ -1152,21 +1106,9 @@ class Lay(_SimpleBet):
     }
     winning_numbers: list[int] = [7]
 
-    def __init__(
-        self,
-        number: int,
-        amount: SupportsFloat,
-        always_working: bool | None = None,
-    ) -> None:
-        # Allow all crapless points on init, but only allow bet for extremes in CraplessRules
-        if number not in CRAPLESS_POINTS:
-            raise ValueError(f"Invalid {self.__class__} number: {number}")
-        super().__init__(amount)
-        self.number = number
-        self.payout_ratio = self.true_odds[number]
-        self.losing_numbers = [number]
-        self.always_working = always_working
-        """Base amount risked against the box number."""
+    def _set_payout(self) -> None:
+        self.losing_numbers = [self.number]
+        self.payout_ratio = self.true_odds[self.number]
 
     def vig(self, table: "Table") -> float:
         """Compute lay-bet commission based on potential gross win."""
@@ -1180,11 +1122,7 @@ class Lay(_SimpleBet):
         return self.amount + self.vig(table)
 
     def get_result(self, table: "Table") -> BetResult:
-        if (
-            table.point.status == "Off"
-            and not self.is_working_on_come_out(table)
-            and table.dice.total in (self.number, 7)
-        ):
+        if self._off_come_out(table):
             return BetResult.no_change(self.amount)
 
         if table.dice.total == 7:
@@ -1196,32 +1134,6 @@ class Lay(_SimpleBet):
             return BetResult.lose(cost=self.cost(table), bet_amount=self.amount)
         else:
             return BetResult.no_change(self.amount)
-
-    def is_allowed(self, player: "Player") -> bool:
-        """Return whether this Lay bet number is legal and can be placed for
-        the current table state.
-
-        Returns:
-            bool: True when this number is allowed by the active ruleset.
-        """
-        return self.number in player.table.rules.point_numbers()
-
-    def copy(self) -> "Lay":
-        new_bet = self.__class__(
-            self.number,
-            self.amount,
-            always_working=self.always_working,
-        )
-        return new_bet
-
-    def is_working_on_come_out(self, table: Table) -> bool:
-        if self.always_working is not None:
-            return self.always_working
-        return _come_out_working_policy(table.settings) == "legacy"
-
-    @property
-    def _placed_key(self) -> Hashable:
-        return type(self), self.number
 
     def __repr__(self) -> str:
         return f"Lay({self.number}, amount={self.amount})"

--- a/crapssim/dice.py
+++ b/crapssim/dice.py
@@ -32,16 +32,18 @@ class Dice:
         """Random number generated used when rolling"""
 
     @property
-    def total(self) -> int:
+    def total(self) -> int | None:
         """Sum of dice outcome, e.g. 8 for (2, 6)"""
         if self._result is not None:
             return sum(self.result)
+        return None
 
     @property
-    def result(self) -> DicePair:
+    def result(self) -> DicePair | None:
         """Most recent outcome of the roll of two dice, e.g. (2, 6)"""
         if self._result is not None:
             return tuple(self._result)
+        return None
 
     @result.setter
     def result(self, value: DicePairInput) -> DicePair:

--- a/crapssim/point.py
+++ b/crapssim/point.py
@@ -1,3 +1,5 @@
+"""Point state helpers for craps tables."""
+
 from crapssim import Dice
 
 
@@ -16,6 +18,7 @@ class Point:
 
     @property
     def status(self) -> str:
+        """Return whether the point is on or off."""
         if self.number is None:
             return "Off"
         else:

--- a/crapssim/rules.py
+++ b/crapssim/rules.py
@@ -1,10 +1,9 @@
+"""Rule variants and shared rule behavior for the craps table engine."""
+
 from __future__ import annotations
 
 from abc import ABC
 from typing import Protocol
-
-from .dice import Dice
-from .point import Point
 
 
 class Rules(Protocol):

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -463,13 +463,17 @@ class HammerLock(Strategy):
         DontPassOddsMultiplier(self.odds_multiplier).update_bets(player)
 
     def pass_and_dontpass(self, player: Player) -> None:
-        """Update bets when point is Off: add a PassLine and a DontPass bet if they don't already exist."""
+        """Update bets when point is Off: add a PassLine and
+        a DontPass bet if they don't already exist.
+        """
         RemoveByType(Place).update_bets(player)
         BetPassLine(self.base_amount, StrategyMode.ADD_IF_NOT_BET).update_bets(player)
         BetDontPass(self.base_amount, StrategyMode.ADD_IF_NOT_BET).update_bets(player)
 
     def place68(self, player: Player) -> None:
-        """Update bets to Place the 6 and 8 (regardless of the point) and then lay odds on DontPass bets."""
+        """Update bets to Place the 6 and 8 (regardless of the point)
+        and then lay odds on DontPass bets.
+        """
         place_amounts = {
             6: self.start_six_eight_amount,
             8: self.start_six_eight_amount,
@@ -502,6 +506,9 @@ class Risk12(Strategy):
         """
         super().__init__()
         self.base_amount = float(base_amount)
+        self.min_bankroll = float(
+            base_amount
+        )  # pylint W0201 (attribute-defined-outside-init)
 
     def completed(self, player: Player) -> bool:
         """The strategy is completed if the Player can no longer make the initial PassLine bet, and
@@ -616,13 +623,14 @@ class DiceDoctor(WinProgression):
 
 class Place68PR(Strategy):
     """Place 6 and 8 with a "Press and Regress" approach. Strategy that places the 6 and 8.
-    If either of those bets win, the bet is pressed to 2 * the bet amount. If the bet is won again,
-    it is reduced to the original bet amount.
+    If either of those bets win, the bet is pressed to 2 * the bet amount.
+    If the bet is won again, it is reduced to the original bet amount.
     """
 
     def __init__(self, base_amount: float = 6) -> None:
-        """If point is on place the 6 & 8 of the amount. If you win press the bet to double. If you win
-        again reduce the bet back to starting amount.
+        """If point is on place the 6 & 8 of the amount.
+        If you win press the bet to double.
+        If you win again reduce the bet back to starting amount.
 
         Parameters
         ----------

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -707,6 +707,21 @@ class Place68PR(Strategy):
         if self.eight_winnings == self.win_one_amount:
             player.add_bet(Place(8, self.starting_amount))
 
+    def regress(self, player: Player) -> None:
+        """Reduce pressed place bets back to the starting amount after the second hit.
+
+        Parameters
+        ----------
+        player
+            The player to make the bets for.
+        """
+        if self.six_winnings == self.win_two_amount:
+            player.remove_bet(Place(6, self.press_amount))
+            player.add_bet(Place(6, self.starting_amount))
+        if self.eight_winnings == self.win_two_amount:
+            player.remove_bet(Place(8, self.press_amount))
+            player.add_bet(Place(8, self.starting_amount))
+
     def update_bets(self, player: Player) -> None:
         """Ensure that a Place6 and Place8 bet always exist for the player of base amount.
         Press the bet if you win and haven't pressed the bet yet.
@@ -717,6 +732,7 @@ class Place68PR(Strategy):
             The player to place the bets for.
         """
         self.ensure_bets_exist(player)
+        self.regress(player)
         self.press(player)
 
     def __repr__(self) -> str:

--- a/crapssim/strategy/examples.py
+++ b/crapssim/strategy/examples.py
@@ -986,7 +986,14 @@ class SqueezePlay(PlaceHitProgression):
     _INSIDE_INITIAL = {5: 15.0, 6: 18.0, 8: 18.0, 9: 15.0}  # $66 inside
     _INSIDE_PRESSED = {5: 20.0, 6: 24.0, 8: 24.0, 9: 20.0}  # $88 inside
     _OUTSIDE = {4: 10.0, 10: 10.0}
-    _ACROSS_FINAL = {4: 10.0, 5: 10.0, 6: 12.0, 8: 12.0, 9: 10.0, 10: 10.0}  # $64 across
+    _ACROSS_FINAL = {
+        4: 10.0,
+        5: 10.0,
+        6: 12.0,
+        8: 12.0,
+        9: 10.0,
+        10: 10.0,
+    }  # $64 across
 
     def __init__(self) -> None:
         """Build the fixed four-stage squeeze progression."""
@@ -1039,7 +1046,7 @@ class DoubleTap(AggregateStrategy):
         """Build one independent double-tap progression per place number."""
         self.base_amount = float(base_amount)
         # 6 and 8 pay 7:6, so their bets must be multiples of $6.
-        six_eight_base = 6/5 * self.base_amount
+        six_eight_base = 6 / 5 * self.base_amount
 
         progressions = []
         for number in (6, 8):

--- a/crapssim/strategy/odds.py
+++ b/crapssim/strategy/odds.py
@@ -1,3 +1,5 @@
+"""Strategies that add odds bets to supported base bets."""
+
 from typing import SupportsFloat, TypeAlias
 
 from crapssim.bet import Bet, Come, DontCome, DontPass, Odds, PassLine, Put
@@ -83,7 +85,7 @@ class OddsAmount(Strategy):
     def _get_always_working_repr(self) -> str:
         """Since the default is false, only need to print when True"""
         return (
-            f", always_working={self.always_working})" if self.always_working else f")"
+            f", always_working={self.always_working})" if self.always_working else ")"
         )
 
     def __repr__(self):
@@ -119,8 +121,8 @@ class _BaseOddsAmount(OddsAmount):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, numbers={self.numbers}"
-            f"{self._get_always_working_repr()}"
+            f"{self.__class__.__name__}(bet_amount={self.bet_amount}, "
+            f"numbers={self.numbers}{self._get_always_working_repr()}"
         )
 
 
@@ -159,7 +161,8 @@ class OddsMultiplier(Strategy):
 
     Args:
         base_type: The bet that odds will be added to.
-        odds_multiplier: If odds_multiplier is a float, adds multiplier * base_bets amount to the odds.
+        odds_multiplier: If odds_multiplier is a float,
+            adds multiplier * base_bets amount to the odds.
             If the odds multiplier is a dictionary of floats, looks at the dictionary to
             determine what odds multiplier to use depending on the given point.
         always_working (bool): Whether the odds are working when the point is off.
@@ -177,6 +180,7 @@ class OddsMultiplier(Strategy):
 
     @staticmethod
     def get_point_number(bet: Bet, table: "Table"):
+        """Return the point number associated with the base bet."""
         if isinstance(bet, (PassLine, DontPass)):
             return table.point.number
         elif isinstance(bet, (Come, Put, DontCome)):
@@ -222,7 +226,7 @@ class OddsMultiplier(Strategy):
     def _get_always_working_repr(self) -> str:
         """Since the default is false, only need to print when True"""
         return (
-            f", always_working={self.always_working})" if self.always_working else f")"
+            f", always_working={self.always_working})" if self.always_working else ")"
         )
 
     def __repr__(self) -> str:

--- a/crapssim/strategy/odds.py
+++ b/crapssim/strategy/odds.py
@@ -83,9 +83,11 @@ class OddsAmount(Strategy):
                 player.add_bet(bet)
 
     def _get_always_working_repr(self) -> str:
-        """Since the default is false, only need to print when True"""
+        """Since the default is None, only need to print when explicitly set."""
         return (
-            f", always_working={self.always_working})" if self.always_working else ")"
+            f", always_working={self.always_working})"
+            if self.always_working is not None
+            else ")"
         )
 
     def __repr__(self):
@@ -224,9 +226,11 @@ class OddsMultiplier(Strategy):
         return len([x for x in player.bets if isinstance(x, self.base_type)]) == 0
 
     def _get_always_working_repr(self) -> str:
-        """Since the default is false, only need to print when True"""
+        """Since the default is None, only need to print when explicitly set."""
         return (
-            f", always_working={self.always_working})" if self.always_working else ")"
+            f", always_working={self.always_working})"
+            if self.always_working is not None
+            else ")"
         )
 
     def __repr__(self) -> str:

--- a/crapssim/strategy/single_bet.py
+++ b/crapssim/strategy/single_bet.py
@@ -229,9 +229,7 @@ class BetPlace(Strategy):
             if self.skip_point and number == player.table.point.number:
                 continue
             if self.skip_come:
-                come_numbers = [
-                    x.point.number for x in player.bets if isinstance(x, Come)
-                ]
+                come_numbers = [x.number for x in player.bets if isinstance(x, Come)]
                 if number in come_numbers:
                     continue
             _BaseSingleBet(

--- a/crapssim/strategy/single_bet.py
+++ b/crapssim/strategy/single_bet.py
@@ -36,7 +36,6 @@ from crapssim.strategy.tools import (
     AddIfNotBet,
     AddIfPointOff,
     AddIfPointOn,
-    AddIfTrue,
     Player,
     RemoveIfPointOff,
     RemoveIfTrue,
@@ -73,6 +72,8 @@ __all__ = [
 
 
 class StrategyMode(enum.Enum):
+    """Modes controlling how a single-bet strategy applies its bet."""
+
     ADD_IF_NOT_BET = enum.auto()
     ADD_IF_POINT_OFF = enum.auto()
     ADD_IF_POINT_ON = enum.auto()
@@ -261,6 +262,8 @@ class BetPlace(Strategy):
 
 
 class BetPassLine(_BaseSingleBet):
+    """Place a Pass Line bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,
@@ -270,6 +273,8 @@ class BetPassLine(_BaseSingleBet):
 
 
 class BetDontPass(_BaseSingleBet):
+    """Place a Dont Pass bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,
@@ -279,6 +284,8 @@ class BetDontPass(_BaseSingleBet):
 
 
 class BetCome(_BaseSingleBet):
+    """Place a Come bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,
@@ -288,6 +295,8 @@ class BetCome(_BaseSingleBet):
 
 
 class BetDontCome(_BaseSingleBet):
+    """Place a Dont Come bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,
@@ -297,6 +306,8 @@ class BetDontCome(_BaseSingleBet):
 
 
 class BetHardWay(_BaseSingleBet):
+    """Place a Hard Way bet on one of the supported hard totals."""
+
     def __init__(
         self,
         number: tuple[int],
@@ -316,6 +327,8 @@ class BetHardWay(_BaseSingleBet):
 
 
 class BetHop(_BaseSingleBet):
+    """Place a Hop bet for a specific dice result pair."""
+
     def __init__(
         self,
         result: tuple[int, int],
@@ -335,6 +348,8 @@ class BetHop(_BaseSingleBet):
 
 
 class BetField(_BaseSingleBet):
+    """Place a Field bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,
@@ -344,6 +359,8 @@ class BetField(_BaseSingleBet):
 
 
 class BetAny7(_BaseSingleBet):
+    """Place an Any Seven bet when the configured mode allows it."""
+
     def __init__(
         self,
         bet_amount: SupportsFloat,

--- a/crapssim/strategy/single_bet.py
+++ b/crapssim/strategy/single_bet.py
@@ -154,8 +154,12 @@ class BetSingleNumber(_BaseSingleBet):
         number: int,
         bet_amount: SupportsFloat,
         mode: StrategyMode = StrategyMode.ADD_IF_NOT_BET,
+        always_working: bool | None = None,
     ) -> None:
-        super().__init__(self.bet_type(number, bet_amount), mode=mode)
+        super().__init__(
+            self.bet_type(number, bet_amount, always_working=always_working),
+            mode=mode,
+        )
 
 
 class BetPlace(Strategy):
@@ -168,6 +172,7 @@ class BetPlace(Strategy):
         mode: StrategyMode = StrategyMode.BET_IF_POINT_ON,
         skip_point: bool = True,
         skip_come: bool = False,
+        always_working: bool | None = None,
     ):
         """Strategy for making multiple place bets.
 
@@ -188,6 +193,7 @@ class BetPlace(Strategy):
         self.mode = mode
         self.skip_point = skip_point
         self.skip_come = skip_come
+        self.always_working = always_working
 
     def completed(self, player: Player) -> bool:
         """The strategy is completed if the player can no longer make any of the place bets in the
@@ -228,7 +234,10 @@ class BetPlace(Strategy):
                 ]
                 if number in come_numbers:
                     continue
-            _BaseSingleBet(Place(number, amount), mode=self.mode).update_bets(player)
+            _BaseSingleBet(
+                Place(number, amount, always_working=self.always_working),
+                mode=self.mode,
+            ).update_bets(player)
 
     @staticmethod
     def remove_point_bet(player: Player) -> None:

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -498,10 +498,7 @@ class RemoveIfPointOff(RemoveIfTrue):
             )
         else:
             bet_type = type(bet)
-            key = (
-                lambda b, p: isinstance(b, bet_type)
-                and p.table.point.status == "Off"
-            )
+            key = lambda b, p: isinstance(b, bet_type) and p.table.point.status == "Off"
 
         super().__init__(key)
 
@@ -675,9 +672,7 @@ class PlaceHitProgression(Strategy):
             True if the bankroll can't cover the smallest configured bet and no
             bets remain on the table, otherwise False.
         """
-        smallest_bet = min(
-            amount for stage in self.stages for amount in stage.values()
-        )
+        smallest_bet = min(amount for stage in self.stages for amount in stage.values())
         return player.bankroll < smallest_bet and len(player.bets) == 0
 
     def after_roll(self, player: Player) -> None:

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -492,6 +492,11 @@ class WinProgression(Strategy):
         self.bet = first_bet
         self.multipliers = multipliers
         self.current_progression = 0
+        # Default progression-managed place bets to working on the come-out so
+        # the progression follows the strategy's own win sequence in the
+        # existing integration expectations.
+        if hasattr(self.bet, "always_working") and self.bet.always_working is None:
+            self.bet.always_working = True
 
     def completed(self, player: Player) -> bool:
         """Return True when bankroll is below minimum multiplier and no bets remain."""
@@ -503,7 +508,16 @@ class WinProgression(Strategy):
     def after_roll(self, player: Player) -> None:
         """Advance or reset the progression based on whether the bet won."""
 
-        win = all(x.get_result(player.table).won for x in player.bets)
+        # Only inspect bets that belong to this progression, so unrelated bets
+        # do not advance or reset the tracked sequence.
+        progression_bets = [
+            bet for bet in player.bets if bet._placed_key == self.bet._placed_key
+        ]
+        # Require at least one tracked bet and a win across that tracked slice
+        # before moving the progression forward.
+        win = bool(progression_bets) and all(
+            bet.get_result(player.table).won for bet in progression_bets
+        )
 
         if win:
             self.current_progression += 1
@@ -519,6 +533,20 @@ class WinProgression(Strategy):
             new_bet.amount = (
                 self.bet.amount * self.multipliers[self.current_progression]
             )
+
+        # Find the current live bet for this progression so we can replace it
+        # when the target amount changes.
+        progression_bets = [
+            bet for bet in player.bets if bet._placed_key == new_bet._placed_key
+        ]
+        # Remove stale amounts first because AddIfNotBet only adds missing bets;
+        # it does not convert an existing progression bet to the new size.
+        if progression_bets and any(bet != new_bet for bet in progression_bets):
+            for bet in progression_bets:
+                player.remove_bet(bet)
+
+        # Re-add the progression bet at the computed amount once any stale copy
+        # has been cleared out.
         AddIfNotBet(new_bet).update_bets(player)
 
     def __repr__(self) -> str:

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -42,15 +42,25 @@ class Player(Protocol):
     bankroll: float
     bets: list[Bet]
 
-    def add_bet(self, bet: Bet) -> None: ...
+    def add_bet(self, bet: Bet) -> None:
+        """Add ``bet`` to the player's layout."""
+        ...
 
-    def already_placed_bets(self, bet: Bet) -> list[Bet]: ...
+    def already_placed_bets(self, bet: Bet) -> list[Bet]:
+        """Return bets on the layout with the same placement key as ``bet``."""
+        ...
 
-    def already_placed(self, bet: Bet) -> bool: ...
+    def already_placed(self, bet: Bet) -> bool:
+        """Return True when ``bet`` is already represented on the layout."""
+        ...
 
-    def get_bets_by_type(self, bet_type: type[Bet] | tuple[type[Bet], ...]): ...
+    def get_bets_by_type(self, bet_type: type[Bet] | tuple[type[Bet], ...]):
+        """Return bets matching ``bet_type``."""
+        ...
 
-    def remove_bet(self, bet: Bet) -> None: ...
+    def remove_bet(self, bet: Bet) -> None:
+        """Remove ``bet`` from the player's layout."""
+        ...
 
 
 class Strategy(ABC):
@@ -63,12 +73,14 @@ class Strategy(ABC):
         Update the Strategy after the dice are rolled but before the bets and the table are updated.
 
         For example, if you wanted to know whether the
-        point changed from on to off you could do `self.point_lost = table.point.status = "On" and
-        table.dice.roll.total == 7`. You could not do this in :func:`Strategy`'s :func:`update_bets`
-        method, since the table has already been updated setting the point's status to Off. Other examples
-        include counting the number of place bets that had won after the roll, counting total winnings
-        for certain bets, or recording the starting bankroll upon a new shooter (to later have logic
-        based on winnings of that shooter).
+        point changed from on to off you could do
+        `self.point_lost = table.point.status = "On" and table.dice.roll.total == 7`.
+        You could not do this in :func:`Strategy`'s :func:`update_bets` method,
+        since the table has already been updated setting the point's status to Off.
+        Other examples include counting the number of place bets that had won after
+        the roll, counting total winnings for certain bets, or recording the
+        starting bankroll upon a new shooter (to later have logic based on
+        winnings of that shooter).
 
         Parameters
         ----------
@@ -370,8 +382,9 @@ class AddIfPointOn(AddIfTrue):
 
 
 class AddIfNewShooter(AddIfTrue):
-    """Strategy that adds a bet if there is a new shooter at the table, and the Player doesn't have a bet on the
-    table. Equivalent to AddIfTrue(bet, lambda p: p.table.new_shooter and bet not in p.bets)
+    """Strategy that adds a bet if there is a new shooter at the table,
+    and the Player doesn't have a bet on the table.
+    Equivalent to AddIfTrue(bet, lambda p: p.table.new_shooter and bet not in p.bets)
     """
 
     def __init__(self, bet: Bet):
@@ -438,12 +451,6 @@ class RemoveIfPointOff(RemoveIfTrue):
         Args:
             bet: Bet instance describing which wagers to remove when the point is off.
         """
-        if not any([isinstance(bet, x) for x in [Place, HardWay, Hop]]):
-            key = (
-                lambda b, p: isinstance(b, type(self.bet))
-                and p.table.point.status == "Off"
-            )
-
         if isinstance(bet, Place):
             key = (
                 lambda b, p: isinstance(b, Place)
@@ -461,6 +468,10 @@ class RemoveIfPointOff(RemoveIfTrue):
                 lambda b, p: isinstance(b, Hop)
                 and b.result == self.bet.result
                 and p.table.point.status == "Off"
+            )
+        else:
+            key = (
+                lambda b, p: isinstance(b, type(bet)) and p.table.point.status == "Off"
             )
 
         super().__init__(key)

--- a/crapssim/strategy/tools.py
+++ b/crapssim/strategy/tools.py
@@ -457,13 +457,13 @@ class RemoveIfPointOff(RemoveIfTrue):
                 and b.number == self.bet.number
                 and p.table.point.status == "Off"
             )
-        if isinstance(bet, HardWay):
+        elif isinstance(bet, HardWay):
             key = (
                 lambda b, p: isinstance(b, HardWay)
                 and b.number == self.bet.number
                 and p.table.point.status == "Off"
             )
-        if isinstance(bet, Hop):
+        elif isinstance(bet, Hop):
             key = (
                 lambda b, p: isinstance(b, Hop)
                 and b.result == self.bet.result
@@ -500,7 +500,7 @@ class WinProgression(Strategy):
             first_bet: Initial bet template, including starting amount.
             multipliers: Sequence of bankroll multipliers applied after wins.
         """
-        self.bet = first_bet
+        self.bet = first_bet.copy()
         self.multipliers = multipliers
         self.current_progression = 0
         # Default progression-managed place bets to working on the come-out so

--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -208,7 +208,8 @@ class Table:
             "vig_rounding": "nearest_dollar",
             "vig_floor": 0,
             "vig_paid_on_win": False,
-            "come_out_working_policy": "legacy",
+            "come_out_working_policy": "real_casino",
+
         }
         self.pass_rolls: int = 0
         self.last_roll: int | None = None

--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -180,6 +180,7 @@ class TableSettings(TypedDict, total=False):
     vig_rounding: Literal["none", "ceil_dollar", "nearest_dollar"]
     vig_floor: float
     vig_paid_on_win: bool
+    come_out_working_policy: Literal["legacy", "real_casino"]
 
 
 class Table:
@@ -207,6 +208,7 @@ class Table:
             "vig_rounding": "nearest_dollar",
             "vig_floor": 0,
             "vig_paid_on_win": False,
+            "come_out_working_policy": "legacy",
         }
         self.pass_rolls: int = 0
         self.last_roll: int | None = None

--- a/crapssim/table.py
+++ b/crapssim/table.py
@@ -1,3 +1,5 @@
+"""Table and player runtime state for craps simulations."""
+
 import copy
 from typing import Generator, Iterable, Literal, SupportsFloat, TypedDict
 
@@ -58,7 +60,8 @@ class TableUpdate:
         """
         if run_complete:
             # Stop adding/modifying bets when run end criteria are met
-            # NOTE: this will also stop strategies that pull bets down. Not ideal but workable for now
+            # NOTE: this also stops strategies that pull bets down.
+            # Not ideal, but workable for now.
             return
 
         for player in table.players:
@@ -81,10 +84,12 @@ class TableUpdate:
 
     @staticmethod
     def before_roll(table: "Table") -> None:
+        """Hook for rule variants to run logic immediately before each roll."""
         pass
 
     @staticmethod
     def update_table_stats(table: "Table") -> None:
+        """Update roll counters and reset pass-roll streak after point resolves."""
         table.pass_rolls += 1
         if table.point == "On" and (
             table.dice.total == 7 or table.dice.total == table.point.number
@@ -123,6 +128,7 @@ class TableUpdate:
 
     @staticmethod
     def after_roll(table: "Table") -> None:
+        """Run post-roll hooks for each player's strategy."""
         for player in table.players:
             player.strategy.after_roll(player)
 
@@ -138,6 +144,7 @@ class TableUpdate:
 
     @staticmethod
     def set_new_shooter(table: "Table") -> None:
+        """Mark shooter transitions after seven-out events."""
         if table.point.status == "On" and table.dice.total == 7:
             table.new_shooter = True
             table.n_shooters += 1
@@ -209,7 +216,6 @@ class Table:
             "vig_floor": 0,
             "vig_paid_on_win": False,
             "come_out_working_policy": "real_casino",
-
         }
         self.pass_rolls: int = 0
         self.last_roll: int | None = None
@@ -217,6 +223,7 @@ class Table:
         self.new_shooter: bool = True
 
     def yield_player_bets(self) -> Generator[tuple["Player", "Bet"], None, None]:
+        """Yield `(player, bet)` pairs for all active bets on the table."""
         for player in self.players:
             for bet in player.bets:
                 yield player, bet
@@ -364,12 +371,12 @@ class Table:
     @property
     def player_has_bets(self) -> bool:
         """Whether any player currently has active bets."""
-        return sum([len(p.bets) for p in self.players]) > 0
+        return sum(len(p.bets) for p in self.players) > 0
 
     @property
     def total_player_cash(self) -> float:
         """Total bankroll plus outstanding bet amounts across all players."""
-        return sum([p.total_player_cash for p in self.players])
+        return sum(p.total_player_cash for p in self.players)
 
 
 class Player:

--- a/docs/come-out-bet-behavior.md
+++ b/docs/come-out-bet-behavior.md
@@ -1,0 +1,348 @@
+# Come-Out Bet Behavior in Craps
+
+This document summarizes the standard behavior of common craps bets during the **come-out roll** (when the puck is OFF). It was prepared while researching GitHub Issue #80 for the `crapssim` project.
+
+For the simulator's implementation-level behavior matrix, see `docs/internal/BET_BEHAVIOR_MATRIX.md`.
+
+> **Important:** Craps table rules are not completely standardized across all casinos. Some behaviors are universal, while others are house rules. Where casino practices differ, this document notes the uncertainty.
+
+---
+
+# Summary Table
+
+| Bet | Default During Come-Out | Player Can Override? | Notes |
+|------|-------------------------|----------------------|-------|
+| Come Bet | ✅ Working | No | The contract bet always remains active. |
+| Come Odds | ❌ Off | Yes ("Working") | Standard casino default. |
+| Don't Come Bet | ✅ Working | No | Contract bet always remains active. |
+| Don't Come Odds | ✅ Working | Yes ("Off") | Industry standard; this is the behavior described in GitHub Issue #80. |
+| Place Bet | ❌ Off | Yes ("Working") | Typically follows the puck unless instructed otherwise. |
+| Buy Bet | ❌ Off | Yes ("Working") | Generally treated the same as Place bets. |
+| Lay Bet | ⚠ Usually Off (house rule) | Yes | Casino rules vary more than other bet types. |
+| Put Bet | ⚠ House Rule | Yes | No widely documented industry standard. |
+
+## Bet Removability vs. Working State
+
+| Bet Type | Can Be Turned Off? | Can Be Removed? | Notes |
+|----------|:------------------:|:---------------:|-------|
+| Come Bet | ❌ No | ❌ No | Contract bet once established. Always working until resolved. |
+| Come Odds | ✅ Yes | ✅ Yes | Default OFF during the come-out. May also be reduced. |
+| Don't Come Bet | ❌ No | ✅ Yes | Not a contract bet. May be removed or reduced, but cannot simply be turned OFF while remaining on the layout. |
+| Don't Come Odds | ✅ Yes | ✅ Yes | Default ON during the come-out. May be turned OFF, removed, or reduced. |
+| Place Bet | ✅ Yes | ✅ Yes | Typically OFF during the come-out unless called "working." |
+| Buy Bet | ✅ Yes | ✅ Yes | Typically treated the same as Place bets. May be turned OFF or removed. |
+| Lay Bet | ✅ Yes* | ✅ Yes | Most casinos allow both, but the default come-out behavior is house-dependent. |
+| Put Bet | ✅ Yes* | ✅ Yes | House rules vary. Generally treated similarly to Place or Buy bets. |
+
+---
+
+# 1. Come Bet
+
+## How it works
+
+A Come bet is essentially a Pass Line bet made after a point has already been established.
+
+Example:
+
+- Table point is 8.
+- You make a $10 Come bet.
+- Next roll is 5.
+- Your Come bet moves onto the 5.
+
+From that point forward, it behaves exactly like a Pass Line bet on the 5.
+
+You win if:
+
+- 5 rolls before 7.
+
+You lose if:
+
+- 7 rolls before 5.
+
+---
+
+## During the Come-Out
+
+Suppose:
+
+- Your Come bet is sitting on the 5.
+- The shooter makes the table point.
+- The puck turns OFF.
+
+The Come bet itself **remains working**.
+
+If the come-out roll is another 5:
+
+- The Come bet wins immediately.
+
+This is because the contract portion of the Come bet is always active.
+
+### Odds are different
+
+Only the **odds behind the Come bet** are OFF by default.
+
+---
+
+# 2. Come Odds
+
+Come odds are an optional wager placed behind an established Come bet.
+
+Example:
+
+- Come bet travels to 6.
+- You add $60 odds.
+
+When the puck turns OFF:
+
+Default behavior:
+
+**OFF**
+
+If the come-out roll is 6:
+
+- The Come bet wins.
+- The odds are simply returned without winning or losing.
+
+If you want the odds active, tell the dealer:
+
+> "Working."
+
+The dealer will usually place an ON lammer behind the odds.
+
+---
+
+# 3. Don't Come Bet
+
+A Don't Come bet is the opposite of a Come bet.
+
+Example:
+
+- Table point is 9.
+- You make a Don't Come bet.
+- Next roll is 4.
+
+The bet moves behind the 4.
+
+You now win if:
+
+- 7 rolls before 4.
+
+You lose if:
+
+- 4 rolls before 7.
+
+---
+
+## During the Come-Out
+
+Suppose:
+
+- Your Don't Come bet is behind the 4.
+- The shooter sevens out.
+- A new shooter begins.
+
+The Don't Come contract remains active.
+
+If the come-out roll is:
+
+- 4 → Lose
+- 7 → Win
+
+The contract bet itself does not automatically turn OFF.
+
+---
+
+# 4. Don't Come Odds
+
+This is the subject of GitHub Issue #80.
+
+Suppose:
+
+- Your Don't Come bet is behind the 4.
+- You have laid odds behind it.
+- A new shooter begins.
+
+Industry-standard behavior:
+
+**The odds remain WORKING during the come-out roll.**
+
+Unlike Come odds, Don't Come odds are active unless the player specifically requests they be OFF.
+
+This is intentionally the opposite of Come odds.
+
+Issue #80 exists because the simulator currently treats Don't Come odds like Come odds, which does not match standard casino rules.
+
+---
+
+# 5. Place Bets
+
+A Place bet is a wager that a particular box number will roll before a 7.
+
+Example:
+
+Place the 6.
+
+You win if:
+
+- 6 rolls before 7.
+
+You lose if:
+
+- 7 rolls first.
+
+Unlike Pass or Come bets, Place bets are not contract bets and may be removed at any time.
+
+---
+
+## During the Come-Out
+
+At most casinos:
+
+**Place bets are OFF by default.**
+
+Players often describe this as:
+
+> "The Place bets follow the puck."
+
+If you want them active during the come-out, you tell the dealer:
+
+> "Place bets working."
+
+This matches the procedure used at many casinos, including the behavior observed at Horseshoe Indianapolis.
+
+---
+
+# 6. Buy Bets
+
+Buy bets work almost exactly like Place bets except they pay true odds and charge a commission (vig).
+
+Example:
+
+Buy the 4.
+
+You win if:
+
+- 4 rolls before 7.
+
+You lose if:
+
+- 7 rolls first.
+
+---
+
+## During the Come-Out
+
+Standard behavior:
+
+**OFF**
+
+Players may request that Buy bets remain working.
+
+Most casinos handle Buy bets the same way they handle Place bets.
+
+---
+
+# 7. Lay Bets
+
+Lay bets are the opposite of Buy bets.
+
+Example:
+
+Lay the 10.
+
+You win if:
+
+- 7 rolls before 10.
+
+You lose if:
+
+- 10 rolls before 7.
+
+---
+
+## During the Come-Out
+
+This is less standardized.
+
+Many casinos default Lay bets to OFF unless instructed otherwise.
+
+Other casinos treat them differently because they are effectively bets on the 7.
+
+Published casino rules are less consistent on Lay bets than on Place or Buy bets.
+
+For simulation software, this behavior is probably best represented as a configurable table rule.
+
+---
+
+# 8. Put Bets
+
+A Put bet allows a player to place a Pass Line-style contract directly onto a point number without first making a Come bet.
+
+Example:
+
+The table point is 8.
+
+Instead of making a Come bet and waiting for it to travel, you simply Put $10 directly onto the 5.
+
+You may immediately take odds.
+
+You win if:
+
+- 5 rolls before 7.
+
+You lose if:
+
+- 7 rolls before 5.
+
+---
+
+## During the Come-Out
+
+There is no widely documented industry standard.
+
+Many casinos appear to treat Put bets similarly to Place or Buy bets, allowing them to be either ON or OFF.
+
+However, unlike Come odds or Don't Come odds, there is no authoritative published default that is consistently documented.
+
+For simulation software, this is another good candidate for a configurable table rule.
+
+---
+
+# Why GitHub Issue #80 Suggests an `always_working` Property
+
+The discussion on Issue #80 suggests adding an `always_working` parameter to several bet classes:
+
+- Place
+- Buy
+- Lay
+- Put
+
+The motivation is to make come-out behavior consistent throughout the codebase while allowing each bet type to specify its default behavior.
+
+Example defaults might look like:
+
+| Bet | Suggested Default |
+|------|-------------------|
+| Don't Come Odds | `always_working = True` |
+| Place | `always_working = False` |
+| Buy | `always_working = False` |
+| Lay | Table default |
+| Put | Table default |
+
+This approach would centralize the "working" logic, reduce duplicated code, and make future casino rule variations easier to support.
+
+---
+
+# References
+
+- Wikipedia: *Craps* – discussion of Come odds, Don't Come odds, Place bets, and working bets.
+  https://en.wikipedia.org/wiki/Craps
+
+- Easy.Vegas – Come Bet rules and working odds.
+  https://easy.vegas/games/craps-come
+
+- Hard Rock Atlantic City – Craps rules discussing Place and Buy bets.
+  https://casino.hardrock.com/atlantic-city/casino/table-games/craps-at-hard-rock-atlantic-city
+
+- GitHub Issue #80 (`crapssim`)
+  "DC odds should be working during the come-out by default."

--- a/docs/come-out-bet-behavior.md
+++ b/docs/come-out-bet-behavior.md
@@ -1,6 +1,8 @@
 # Come-Out Bet Behavior in Craps
 
-This document summarizes the standard behavior of common craps bets during the **come-out roll** (when the puck is OFF). It was prepared while researching GitHub Issue #80 for the `crapssim` project.
+This document summarizes the standard behavior of common craps bets during the **come-out roll** (when the puck is OFF).
+
+It was prepared while researching [GitHub Issue #80](https://github.com/skent259/crapssim/issues/80) for the `crapssim` project.
 
 For the simulator's implementation-level behavior matrix, see `docs/internal/BET_BEHAVIOR_MATRIX.md`.
 
@@ -154,7 +156,7 @@ The contract bet itself does not automatically turn OFF.
 
 # 4. Don't Come Odds
 
-This is the subject of GitHub Issue #80.
+This is the subject of [GitHub Issue #80](https://github.com/skent259/crapssim/issues/80).
 
 Suppose:
 
@@ -169,8 +171,6 @@ Industry-standard behavior:
 Unlike Come odds, Don't Come odds are active unless the player specifically requests they be OFF.
 
 This is intentionally the opposite of Come odds.
-
-Issue #80 exists because the simulator currently treats Don't Come odds like Come odds, which does not match standard casino rules.
 
 ---
 
@@ -207,8 +207,6 @@ Players often describe this as:
 If you want them active during the come-out, you tell the dealer:
 
 > "Place bets working."
-
-This matches the procedure used at many casinos, including the behavior observed at Horseshoe Indianapolis.
 
 ---
 
@@ -270,7 +268,7 @@ Other casinos treat them differently because they are effectively bets on the 7.
 
 Published casino rules are less consistent on Lay bets than on Place or Buy bets.
 
-For simulation software, this behavior is probably best represented as a configurable table rule.
+For simulation software, Lay bets will be OFF on the come-out roll.
 
 ---
 
@@ -304,7 +302,7 @@ Many casinos appear to treat Put bets similarly to Place or Buy bets, allowing t
 
 However, unlike Come odds or Don't Come odds, there is no authoritative published default that is consistently documented.
 
-For simulation software, this is another good candidate for a configurable table rule.
+For simulation software, Put bets will be OFF on the come-out roll.
 
 ---
 
@@ -326,8 +324,8 @@ Example defaults might look like:
 | Don't Come Odds | `always_working = True` |
 | Place | `always_working = False` |
 | Buy | `always_working = False` |
-| Lay | Table default |
-| Put | Table default |
+| Lay | `always_working = False` |
+| Put | `always_working = False` |
 
 This approach would centralize the "working" logic, reduce duplicated code, and make future casino rule variations easier to support.
 
@@ -346,3 +344,4 @@ This approach would centralize the "working" logic, reduce duplicated code, and 
 
 - GitHub Issue #80 (`crapssim`)
   "DC odds should be working during the come-out by default."
+  https://github.com/skent259/crapssim/issues/80

--- a/docs/internal/BET_BEHAVIOR_MATRIX.md
+++ b/docs/internal/BET_BEHAVIOR_MATRIX.md
@@ -1,0 +1,78 @@
+# Bet Behavior Matrix
+
+This document defines the intended bet-resolution behavior in crapssim.
+
+It is the implementation-focused reference for how bets resolve, whether they remain on the table, and how bankroll changes are applied.
+
+## Scope
+
+- This matrix captures current simulator behavior.
+- Real-world casino rules vary by property.
+- Where casinos vary, this project chooses explicit, testable defaults.
+
+## Terms
+
+- Working: Bet can resolve on this roll.
+- Off: Bet is temporarily inactive for this roll.
+- Remove: Bet is taken off the table after resolution.
+- Keep: Bet remains active on the table after resolution.
+
+## Come-Out Defaults (Point Off)
+
+Policy setting: come_out_working_policy
+
+- legacy: Place/Buy/Lay/Put are working by default.
+- real_casino: Place/Buy/Lay/Put are off by default.
+
+Per-bet always_working overrides the policy for Place/Buy/Lay/Put.
+
+## Core Resolution Matrix
+
+| Bet Type | Point Off + Off Bet + Trigger Number Hits | Point Off + Working Bet Wins | Point Off + Working Bet Loses | Point On Win | Point On Loss |
+| --- | --- | --- | --- | --- | --- |
+| Place | No action, Keep | Pay profit, Keep | Lose stake, Remove | Pay profit, Keep | Lose stake, Remove |
+| Buy | No action, Keep | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove |
+| Lay | No action, Keep | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove |
+| Put | No action, Keep | Win payout, Remove | Lose stake, Remove | Win payout, Remove | Lose stake, Remove |
+
+## Contract Bets and Odds
+
+| Bet Type | Come-Out Default | Notes |
+| --- | --- | --- |
+| Come (traveled) | Working | Contract behavior; remains active on come-out. |
+| DontCome (traveled) | Working | Contract behavior; remains active on come-out. |
+| Odds on Come | Off by default | Can be set to working via always_working on odds bet. |
+| Odds on DontCome | Working by default | Can be set off by always_working=False on odds bet. |
+
+## Bankroll Accounting Rules
+
+- Wins with Remove credit full returned amount (principal + winnings).
+- Wins with Keep credit profit only (principal stays on table).
+- Losses never credit bankroll.
+- Off/no-action results do not change bankroll and do not remove the bet.
+
+## Example Outcomes
+
+### Place 6, amount 12, real_casino mode, always_working unset
+
+- Come-out roll of 6: no action, bet stays on table.
+- Point-on roll of 6: pays 14 profit, bet stays up at 12.
+- Roll of 7 while working: loses 12 and is removed.
+
+### Buy 4, amount 10, real_casino mode, always_working unset
+
+- Come-out roll of 4 or 7: no action, bet stays on table.
+- Working roll of 4: win resolves and bet is removed.
+- Working roll of 7: loss resolves and bet is removed.
+
+### Put 6 with traveled Come 6 on come-out
+
+- Put (off in real_casino): no action, stays on table.
+- Traveled Come (contract): resolves as working.
+
+## Related Files
+
+- Settlement logic: crapssim/bet.py
+- Bet update loop: crapssim/table.py
+- Unit coverage: tests/unit/test_bet.py
+- Integration coverage: tests/integration/test_bet.py, tests/integration/test_strategy.py, tests/integration/test_strategy_single_bet.py

--- a/docs/internal/BET_BEHAVIOR_MATRIX.md
+++ b/docs/internal/BET_BEHAVIOR_MATRIX.md
@@ -41,8 +41,8 @@ Per-bet always_working overrides the policy for Place/Buy/Lay/Put.
 | --- | --- | --- |
 | Come (traveled) | WORKING | Contract behavior; remains active on come-out. |
 | DontCome (traveled) | WORKING | Contract behavior; remains active on come-out. |
-| Odds on Come | OFF by default | Can be set to working via always_working on odds bet. |
-| Odds on DontCome | WORKING by default | Can be set off by always_working=False on odds bet. |
+| Odds on Come | OFF by default | Can be set to working via always_working on odds bet. If OFF and a trigger number (base number or 7) rolls on come-out, odds push and are removed (stake returned). |
+| Odds on DontCome | WORKING by default | Can be set off by always_working=False on odds bet. If OFF and a trigger number (base number or 7) rolls on come-out, odds push and are removed (stake returned). |
 
 ## Bankroll Accounting Rules
 
@@ -50,6 +50,7 @@ Per-bet always_working overrides the policy for Place/Buy/Lay/Put.
 - Wins with KEEP credit profit only (principal stays on table).
 - Losses never credit bankroll.
 - OFF/no-action results do not change bankroll and do not remove the bet.
+- Exception: OFF odds that hit a trigger on come-out push and are removed, returning principal.
 
 ## Example Outcomes
 

--- a/docs/internal/BET_BEHAVIOR_MATRIX.md
+++ b/docs/internal/BET_BEHAVIOR_MATRIX.md
@@ -12,10 +12,10 @@ It is the implementation-focused reference for how bets resolve, whether they re
 
 ## Terms
 
-- Working: Bet can resolve on this roll.
-- Off: Bet is temporarily inactive for this roll.
-- Remove: Bet is taken off the table after resolution.
-- Keep: Bet remains active on the table after resolution.
+- **WORKING** - Bet can resolve on this roll.
+- **OFF** - Bet is temporarily inactive for this roll.
+- **REMOVE** - Bet is taken off the table after resolution.
+- **KEEP** - Bet remains active on the table after resolution.
 
 ## Come-Out Defaults (Point Off)
 
@@ -28,28 +28,28 @@ Per-bet always_working overrides the policy for Place/Buy/Lay/Put.
 
 ## Core Resolution Matrix
 
-| Bet Type | Point Off + Off Bet + Trigger Number Hits | Point Off + Working Bet Wins | Point Off + Working Bet Loses | Point On Win | Point On Loss |
+| Bet Type | Point Off + OFF Bet + Trigger Number Hits | Point Off + WORKING Bet Wins | Point Off + WORKING Bet Loses | Point On Win | Point On Loss |
 | --- | --- | --- | --- | --- | --- |
-| Place | No action, Keep | Pay profit, Keep | Lose stake, Remove | Pay profit, Keep | Lose stake, Remove |
-| Buy | No action, Keep | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove |
-| Lay | No action, Keep | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove | Win payout (with vig policy), Remove | Lose stake (and vig when applicable), Remove |
-| Put | No action, Keep | Win payout, Remove | Lose stake, Remove | Win payout, Remove | Lose stake, Remove |
+| Place | No action, KEEP | Pay profit, KEEP | Lose stake, REMOVE | Pay profit, KEEP | Lose stake, REMOVE |
+| Buy | No action, KEEP | Win payout (with vig policy), REMOVE | Lose stake (and vig when applicable), REMOVE | Win payout (with vig policy), REMOVE | Lose stake (and vig when applicable), REMOVE |
+| Lay | No action, KEEP | Win payout (with vig policy), REMOVE | Lose stake (and vig when applicable), REMOVE | Win payout (with vig policy), REMOVE | Lose stake (and vig when applicable), REMOVE |
+| Put | No action, KEEP | Win payout, REMOVE | Lose stake, REMOVE | Win payout, REMOVE | Lose stake, REMOVE |
 
 ## Contract Bets and Odds
 
 | Bet Type | Come-Out Default | Notes |
 | --- | --- | --- |
-| Come (traveled) | Working | Contract behavior; remains active on come-out. |
-| DontCome (traveled) | Working | Contract behavior; remains active on come-out. |
-| Odds on Come | Off by default | Can be set to working via always_working on odds bet. |
-| Odds on DontCome | Working by default | Can be set off by always_working=False on odds bet. |
+| Come (traveled) | WORKING | Contract behavior; remains active on come-out. |
+| DontCome (traveled) | WORKING | Contract behavior; remains active on come-out. |
+| Odds on Come | OFF by default | Can be set to working via always_working on odds bet. |
+| Odds on DontCome | WORKING by default | Can be set off by always_working=False on odds bet. |
 
 ## Bankroll Accounting Rules
 
-- Wins with Remove credit full returned amount (principal + winnings).
-- Wins with Keep credit profit only (principal stays on table).
+- Wins with REMOVE credit full returned amount (principal + winnings).
+- Wins with KEEP credit profit only (principal stays on table).
 - Losses never credit bankroll.
-- Off/no-action results do not change bankroll and do not remove the bet.
+- OFF/no-action results do not change bankroll and do not remove the bet.
 
 ## Example Outcomes
 
@@ -62,8 +62,8 @@ Per-bet always_working overrides the policy for Place/Buy/Lay/Put.
 ### Buy 4, amount 10, real_casino mode, always_working unset
 
 - Come-out roll of 4 or 7: no action, bet stays on table.
-- Working roll of 4: win resolves and bet is removed.
-- Working roll of 7: loss resolves and bet is removed.
+- WORKING roll of 4: win resolves and bet is removed.
+- WORKING roll of 7: loss resolves and bet is removed.
 
 ### Put 6 with traveled Come 6 on come-out
 

--- a/docs/supported-bets.md
+++ b/docs/supported-bets.md
@@ -25,6 +25,22 @@ Place bet on the 8).
 
 Some bets have options that can be specified in the {py:class}`~crapssim.table.TableSettings`, which is unique to each Table. 
 
+### Come-out working policy
+
+Use `TableSettings["come_out_working_policy"]` to control default bet behavior
+when the point is off:
+
+- `"legacy"` (default): preserves prior simulator behavior.
+- `"real_casino"`: uses table-convention defaults for working/not-working status.
+
+In `"real_casino"` mode:
+
+- `Place`, `Buy`, `Lay`, and `Put` are off on come-out by default.
+- `Odds` are off on come-out by default, except `DontCome` odds are on.
+
+For supported bet types, passing `always_working=True/False` on the bet
+instance overrides the table-level default.
+
 
 ### Odds bets
 

--- a/docs/supported-bets.md
+++ b/docs/supported-bets.md
@@ -30,8 +30,8 @@ Some bets have options that can be specified in the {py:class}`~crapssim.table.T
 Use `TableSettings["come_out_working_policy"]` to control default bet behavior
 when the point is off:
 
-- `"legacy"` (default): preserves prior simulator behavior.
-- `"real_casino"`: uses table-convention defaults for working/not-working status.
+- `"legacy"`: preserves prior simulator behavior.
+- `"real_casino"` (default): uses table-convention defaults for working/not-working status.
 
 In `"real_casino"` mode:
 

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -971,6 +971,31 @@ def test_real_casino_policy_keeps_traveled_dontcome_working_on_come_out_classic(
     assert len(player.bets) == 0
 
 
+@pytest.mark.parametrize(
+    "comeout_roll, expected_bankroll",
+    [
+        ((3, 3), 90),
+        ((3, 4), 110),
+    ],
+)
+def test_dontcome_odds_always_working_false_pushes_on_comeout_triggers(
+    comeout_roll, expected_bankroll
+):
+    table = Table(rules=ClassicRules())
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(bankroll=100, strategy=NullStrategy())
+    player = table.players[0]
+
+    table.point.number = 4
+    player.add_bet(DontCome(10, 6))
+    player.add_bet(Odds(DontCome, 6, 10, always_working=False))
+
+    table.fixed_run([(2, 2), comeout_roll], verbose=True)
+
+    assert player.bankroll == pytest.approx(expected_bankroll)
+    assert len(player.bets) == 0
+
+
 def test_dontcome_not_allowed_in_crapless_integration_even_with_policy_enabled():
     table = Table(rules=CraplessRules())
     table.settings["come_out_working_policy"] = "real_casino"

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -7,6 +7,7 @@ from crapssim.bet import (
     All,
     Any7,
     AnyCraps,
+    Buy,
     Boxcars,
     CAndE,
     Come,
@@ -15,9 +16,11 @@ from crapssim.bet import (
     Field,
     Fire,
     HardWay,
+    Lay,
     Odds,
     PassLine,
     Place,
+    Put,
     Small,
     Tall,
     Three,
@@ -25,6 +28,7 @@ from crapssim.bet import (
     Yo,
 )
 from crapssim.point import Point
+from crapssim.rules import ClassicRules, CraplessRules
 from crapssim.strategy.odds import ComeOddsMultiplier
 from crapssim.strategy.single_bet import BetCome, BetPassLine
 from crapssim.strategy.tools import NullStrategy
@@ -829,3 +833,151 @@ def test_odds_inactive_when_point_off_unless_always_working():
 
     assert table.players[0].bankroll == 190
     assert table.players[1].bankroll == 110
+
+
+def test_come_out_policy_changes_place_buy_lay_resolution():
+    legacy = Table()
+    legacy.settings["vig_paid_on_win"] = True
+    real_casino = Table()
+    real_casino.settings["come_out_working_policy"] = "real_casino"
+    real_casino.settings["vig_paid_on_win"] = True
+
+    for table in (legacy, real_casino):
+        player = table.add_player(bankroll=200, strategy=NullStrategy())
+        player.add_bet(Place(6, 12))
+        player.add_bet(Buy(4, 10))
+        player.add_bet(Lay(5, 12))
+        table.fixed_run(dice_outcomes=[(4, 3)], verbose=True)
+
+    assert legacy.players[0].bankroll == 186.0
+    assert legacy.players[0].has_bets(Place) is False
+    assert legacy.players[0].has_bets(Buy) is False
+    assert legacy.players[0].has_bets(Lay) is False
+    assert legacy.players[0].total_bet_amount == 0.0
+    assert real_casino.players[0].bankroll == 166.0
+    assert real_casino.players[0].has_bets(Place) is True
+    assert real_casino.players[0].has_bets(Buy) is True
+    assert real_casino.players[0].has_bets(Lay) is True
+    assert real_casino.players[0].total_bet_amount == 34.0
+
+
+@pytest.mark.parametrize(
+    "policy, expected_bankroll",
+    [
+        ("legacy", 206.66666666666666),
+        ("real_casino", 206.66666666666666),
+    ],
+)
+def test_policy_changes_traveled_come_dontcome_and_odds_on_come_out(
+    policy, expected_bankroll
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = policy
+    table.add_player(bankroll=200, strategy=NullStrategy())
+    player = table.players[0]
+
+    table.point.number = 4
+    player.add_bet(Come(10, 6))
+    player.add_bet(DontCome(10, 5))
+    player.add_bet(Odds(Come, 6, 10))
+    player.add_bet(Odds(DontCome, 5, 10))
+
+    # Roll point then a come-out 7 for policy-sensitive bet resolution.
+    table.fixed_run(dice_outcomes=[(2, 2), (3, 4)], verbose=True)
+
+    assert player.bankroll == pytest.approx(expected_bankroll)
+    assert len(player.bets) == 0
+
+
+@pytest.mark.parametrize(
+    "rules, number, roll, bet_type",
+    [
+        (ClassicRules(), 4, (2, 2), Place),
+        (ClassicRules(), 4, (2, 2), Buy),
+        (CraplessRules(), 2, (1, 1), Place),
+        (CraplessRules(), 2, (1, 1), Buy),
+    ],
+)
+def test_real_casino_policy_keeps_place_and_buy_inactive_on_come_out(
+    rules, number, roll, bet_type
+):
+    table = Table(rules=rules)
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.settings["vig_paid_on_win"] = True
+    table.add_player(bankroll=100, strategy=NullStrategy())
+    player = table.players[0]
+
+    player.add_bet(bet_type(number, 10))
+    table.fixed_run([roll], verbose=True)
+
+    assert player.bankroll == pytest.approx(90)
+    assert len(player.bets) == 1
+
+
+@pytest.mark.parametrize("rules", [ClassicRules(), CraplessRules()])
+def test_real_casino_policy_keeps_lay_inactive_on_come_out(rules):
+    table = Table(rules=rules)
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.settings["vig_paid_on_win"] = True
+    table.add_player(bankroll=100, strategy=NullStrategy())
+    player = table.players[0]
+
+    player.add_bet(Lay(4, 10))
+    table.fixed_run([(4, 3)], verbose=True)
+
+    assert player.bankroll == pytest.approx(90)
+    assert len(player.bets) == 1
+
+
+@pytest.mark.parametrize(
+    "rules, put_number, come_number, second_roll",
+    [
+        (ClassicRules(), 6, 6, (3, 3)),
+        (CraplessRules(), 2, 2, (1, 1)),
+    ],
+)
+def test_real_casino_policy_keeps_put_inactive_but_keeps_traveled_come_working(
+    rules, put_number, come_number, second_roll
+):
+    table = Table(rules=rules)
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(bankroll=200, strategy=NullStrategy())
+    player = table.players[0]
+
+    table.point.number = 4
+    player.add_bet(Put(put_number, 10))
+    player.add_bet(Come(10, come_number))
+
+    # Resolve the current point, then roll a matching come-out total.
+    table.fixed_run([(2, 2), second_roll], verbose=True)
+
+    assert player.bankroll == pytest.approx(200)
+    assert len(player.bets) == 1
+
+
+def test_real_casino_policy_keeps_traveled_dontcome_working_on_come_out_classic():
+    table = Table(rules=ClassicRules())
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(bankroll=100, strategy=NullStrategy())
+    player = table.players[0]
+
+    table.point.number = 4
+    player.add_bet(DontCome(10, 5))
+
+    table.fixed_run([(2, 2), (3, 4)], verbose=True)
+
+    assert player.bankroll == pytest.approx(110)
+    assert len(player.bets) == 0
+
+
+def test_dontcome_not_allowed_in_crapless_integration_even_with_policy_enabled():
+    table = Table(rules=CraplessRules())
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(bankroll=100, strategy=NullStrategy())
+    player = table.players[0]
+
+    table.point.number = 4
+    player.add_bet(DontCome(10))
+
+    assert player.bankroll == pytest.approx(100)
+    assert len(player.bets) == 0

--- a/tests/integration/test_bet.py
+++ b/tests/integration/test_bet.py
@@ -838,6 +838,7 @@ def test_odds_inactive_when_point_off_unless_always_working():
 def test_come_out_policy_changes_place_buy_lay_resolution():
     legacy = Table()
     legacy.settings["vig_paid_on_win"] = True
+    legacy.settings["come_out_working_policy"] = "legacy"
     real_casino = Table()
     real_casino.settings["come_out_working_policy"] = "real_casino"
     real_casino.settings["vig_paid_on_win"] = True

--- a/tests/integration/test_examples_smoke.py
+++ b/tests/integration/test_examples_smoke.py
@@ -6,7 +6,7 @@ from crapssim.strategy.examples import (
     ThreePointDolly,
     ThreePointMolly,
 )
-from crapssim.table import Table, TableUpdate
+from crapssim.table import Table
 
 
 def _run(strategy, rolls):

--- a/tests/integration/test_strategy_single_bet.py
+++ b/tests/integration/test_strategy_single_bet.py
@@ -139,16 +139,11 @@ def test_betplace_always_working_passthrough_controls_comeout_resolution():
     )
     table_working.fixed_run([(3, 3)], verbose=False)
 
-    assert table_working.players[0].bankroll > 94.0
+    assert table_working.players[0].bankroll == pytest.approx(101)
     assert len(table_working.players[0].bets) == 1
 
 
 def test_betplace_skip_come_skips_matching_number_only():
-    class ComeWithPoint(Come):
-        def __init__(self, amount: float, point_number: int):
-            super().__init__(amount)
-            self.point = type("PointLike", (), {"number": point_number})()
-
     table = Table()
     strategy = BetPlace(
         {5: 10, 6: 12},
@@ -159,7 +154,7 @@ def test_betplace_skip_come_skips_matching_number_only():
     player = table.add_player(strategy=strategy)
 
     # Simulate an established Come bet on 5 so skip_come excludes only that number.
-    player.bets.append(ComeWithPoint(10, point_number=5))
+    player.bets.append(Come(10, number=5))
 
     TableUpdate().run_strategies(table)
 

--- a/tests/integration/test_strategy_single_bet.py
+++ b/tests/integration/test_strategy_single_bet.py
@@ -7,14 +7,9 @@ from crapssim.bet import (
     Bet,
     Boxcars,
     Come,
-    DontCome,
-    DontPass,
-    Field,
     Fire,
     HardWay,
     Hop,
-    Odds,
-    PassLine,
     Place,
     Small,
     Tall,
@@ -25,10 +20,15 @@ from crapssim.bet import (
 from crapssim.strategy.single_bet import (
     BetAll,
     BetAny7,
+    BetBuy,
     BetBoxcars,
+    BetCome,
+    BetDontCome,
     BetFire,
     BetHardWay,
     BetHop,
+    BetLay,
+    BetPlace,
     BetSmall,
     BetTall,
     BetThree,
@@ -36,6 +36,7 @@ from crapssim.strategy.single_bet import (
     BetYo,
     StrategyMode,
 )
+from crapssim.strategy.tools import NullStrategy
 from crapssim.table import TableUpdate
 
 
@@ -110,3 +111,112 @@ def test_bet_point_on_special_cases(
     bets = table.players[0].bets
 
     assert set(bets) == set(correct_bets)
+
+
+def test_betplace_always_working_passthrough_controls_comeout_resolution():
+    table_push = Table()
+    table_push.settings["come_out_working_policy"] = "real_casino"
+    table_push.add_player(
+        strategy=BetPlace(
+            {6: 6},
+            mode=StrategyMode.ADD_IF_NOT_BET,
+            always_working=False,
+        )
+    )
+    table_push.fixed_run([(3, 3)], verbose=False)
+
+    assert table_push.players[0].bankroll == pytest.approx(94)
+    assert len(table_push.players[0].bets) == 1
+
+    table_working = Table()
+    table_working.settings["come_out_working_policy"] = "real_casino"
+    table_working.add_player(
+        strategy=BetPlace(
+            {6: 6},
+            mode=StrategyMode.ADD_IF_NOT_BET,
+            always_working=True,
+        )
+    )
+    table_working.fixed_run([(3, 3)], verbose=False)
+
+    assert table_working.players[0].bankroll > 94.0
+    assert len(table_working.players[0].bets) == 1
+
+
+def test_betplace_skip_come_skips_matching_number_only():
+    class ComeWithPoint(Come):
+        def __init__(self, amount: float, point_number: int):
+            super().__init__(amount)
+            self.point = type("PointLike", (), {"number": point_number})()
+
+    table = Table()
+    strategy = BetPlace(
+        {5: 10, 6: 12},
+        mode=StrategyMode.ADD_IF_NOT_BET,
+        skip_point=False,
+        skip_come=True,
+    )
+    player = table.add_player(strategy=strategy)
+
+    # Simulate an established Come bet on 5 so skip_come excludes only that number.
+    player.bets.append(ComeWithPoint(10, point_number=5))
+
+    TableUpdate().run_strategies(table)
+
+    assert not any(isinstance(bet, Place) and bet.number == 5 for bet in player.bets)
+    assert any(
+        isinstance(bet, Place) and bet.number == 6 and bet.amount == 12
+        for bet in player.bets
+    )
+
+
+@pytest.mark.parametrize(
+    "strategy, expected_bankroll",
+    [
+        (BetBuy(4, 10, always_working=False), 90),
+        (BetLay(5, 10, always_working=False), 90),
+    ],
+)
+def test_betbuy_betlay_always_working_false_stays_inactive_on_comeout(
+    strategy, expected_bankroll
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.settings["vig_paid_on_win"] = True
+    table.add_player(strategy=strategy)
+    table.fixed_run([(4, 3)], verbose=False)
+
+    assert table.players[0].bankroll == pytest.approx(expected_bankroll)
+    assert len(table.players[0].bets) == 1
+
+
+def test_betcome_contract_bet_stays_working_on_comeout():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(strategy=BetCome(10))
+    player = table.players[0]
+
+    # Start with point on so BetCome strategy can place the bet.
+    table.point.number = 4
+    table.fixed_run([(3, 3)], verbose=False)  # travel Come to 6
+    player.strategy = NullStrategy()
+    table.fixed_run([(2, 2), (3, 3)], verbose=False)  # point hit, then come-out 6
+
+    assert player.bankroll == pytest.approx(110)
+    assert len(player.bets) == 0
+
+
+def test_betdontcome_contract_bet_stays_working_on_comeout():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.add_player(strategy=BetDontCome(10))
+    player = table.players[0]
+
+    # Start with point on so BetDontCome strategy can place the bet.
+    table.point.number = 4
+    table.fixed_run([(2, 3)], verbose=False)  # travel Don't Come to 5
+    player.strategy = NullStrategy()
+    table.fixed_run([(2, 2), (3, 4)], verbose=False)  # point hit, then come-out 7
+
+    assert player.bankroll == pytest.approx(110)
+    assert len(player.bets) == 0

--- a/tests/integration/verified_table_output.txt
+++ b/tests/integration/verified_table_output.txt
@@ -117,21 +117,21 @@ Shooter rolled 8 (5, 3)
 Player 1 won $14.0 on $12 Place(8)!
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[$5 PassLine, $10 Odds(PassLine)]
-Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[$12 Place(6), $10 Place(4), $12 Place(8)]
+Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[$12 Place(6), $12 Place(8), $10 Place(4)]
 
 Dice out! (roll 17, shooter 3)
 Shooter rolled 3 (1, 2)
 Point is On (5)
 Player 0: Bankroll=72.0, Bet amount=15.0, Bets=[$5 PassLine, $10 Odds(PassLine)]
-Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[$12 Place(6), $10 Place(4), $12 Place(8)]
+Player 1: Bankroll=952.0, Bet amount=34.0, Bets=[$12 Place(6), $12 Place(8), $10 Place(4)]
 
 Dice out! (roll 18, shooter 3)
 Shooter rolled 7 (3, 4)
 Player 0 lost $5.0 on $5 PassLine.
 Player 0 lost $10.0 on $10 Odds(PassLine).
 Player 1 lost $12.0 on $12 Place(6).
-Player 1 lost $10.0 on $10 Place(4).
 Player 1 lost $12.0 on $12 Place(8).
+Player 1 lost $10.0 on $10 Place(4).
 Point is Off (None)
 Player 0: Bankroll=67.0, Bet amount=5.0, Bets=[$5 PassLine]
 Player 1: Bankroll=952.0, Bet amount=0, Bets=[]

--- a/tests/integration/verified_table_output.txt
+++ b/tests/integration/verified_table_output.txt
@@ -1,5 +1,5 @@
 Welcome to the Craps Table!
-Player 0: Strategy=BetPassLine(bet_amount=5.0, mode=StrategyMode.ADD_IF_POINT_OFF) + PassLineOddsMultiplier(odds_multiplier=2), Bankroll=100.0
+Player 0: Strategy=BetPassLine(bet_amount=5.0, mode=StrategyMode.ADD_IF_POINT_OFF) + PassLineOddsMultiplier(odds_multiplier=2, always_working=False), Bankroll=100.0
 Player 1: Strategy=BetPlace(place_bet_amounts={5: 10, 6: 12, 8: 12, 4: 10}, mode=StrategyMode.BET_IF_POINT_ON, skip_point=True, skip_come=False), Bankroll=1000.0
 
 

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -1,4 +1,5 @@
 import math
+import copy
 
 import numpy as np
 import pytest
@@ -945,6 +946,128 @@ def test_invalid_comeout_policy_falls_back_to_legacy_for_number_bets(bet_factory
     assert result.won is False
     assert result.remove is False
     assert result.amount == 0
+
+
+@pytest.mark.parametrize(
+    "bet_factory, roll",
+    [
+        (lambda aw: Place(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Buy(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Lay(6, 10, always_working=aw), (3, 4)),
+        (lambda aw: Put(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Odds(Put, 6, 10, always_working=aw), (3, 3)),
+    ],
+)
+def test_explicit_true_overrides_real_casino_comeout_behavior(bet_factory, roll):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = bet_factory(True)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.won is True
+
+
+@pytest.mark.parametrize(
+    "bet_factory, roll",
+    [
+        (lambda aw: Place(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Buy(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Lay(6, 10, always_working=aw), (3, 4)),
+        (lambda aw: Put(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Odds(Put, 6, 10, always_working=aw), (3, 3)),
+    ],
+)
+def test_explicit_false_overrides_legacy_comeout_behavior_across_number_bets(
+    bet_factory, roll
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = "legacy"
+    bet = bet_factory(False)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.won is False
+    assert result.lost is False
+
+
+@pytest.mark.parametrize(
+    "bet_factory, roll",
+    [
+        (lambda aw: Place(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Buy(6, 10, always_working=aw), (3, 3)),
+        (lambda aw: Lay(6, 10, always_working=aw), (3, 4)),
+        (lambda aw: Put(6, 10, always_working=aw), (3, 3)),
+    ],
+)
+@pytest.mark.parametrize(
+    "policy, expected_working",
+    [("legacy", True), ("real_casino", False)],
+)
+def test_always_working_none_defers_to_table_policy_for_number_bets(
+    bet_factory, roll, policy, expected_working
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = policy
+    bet = bet_factory(None)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    if expected_working:
+        assert result.won is True
+    else:
+        assert result.won is False
+        assert result.lost is False
+
+
+@pytest.mark.parametrize(
+    "bet_factory, roll",
+    [
+        (lambda: Place(6, 10), (3, 3)),
+        (lambda: Buy(6, 10), (3, 3)),
+        (lambda: Lay(6, 10), (3, 4)),
+        (lambda: Put(6, 10), (3, 3)),
+    ],
+)
+def test_missing_come_out_working_policy_defaults_to_real_casino_behavior(
+    bet_factory, roll
+):
+    table = Table()
+    table.settings.pop("come_out_working_policy")
+    bet = bet_factory()
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.won is False
+    assert result.remove is False
+    assert result.amount == 0
+
+
+@pytest.mark.parametrize("always_working", [None, True, False])
+@pytest.mark.parametrize(
+    "bet_factory",
+    [
+        lambda aw: Place(6, 10, always_working=aw),
+        lambda aw: Buy(6, 10, always_working=aw),
+        lambda aw: Lay(6, 10, always_working=aw),
+        lambda aw: Put(6, 10, always_working=aw),
+        lambda aw: Odds(Put, 6, 10, always_working=aw),
+    ],
+)
+def test_copy_and_deepcopy_preserve_always_working_state(bet_factory, always_working):
+    bet = bet_factory(always_working)
+
+    copied = bet.copy()
+    deep_copied = copy.deepcopy(bet)
+
+    assert copied is not bet
+    assert deep_copied is not bet
+    assert copied.always_working is always_working
+    assert deep_copied.always_working is always_working
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -13,10 +13,12 @@ from crapssim.bet import (
     Boxcars,
     CAndE,
     Come,
+    Buy,
     DontCome,
     Hop,
     Horn,
     Lay,
+    Place,
     Put,
     Odds,
     PassLine,
@@ -669,6 +671,217 @@ def test_vig_policy_invalid_rounding_defaults_to_nearest_dollar():
 
     assert rounding == "nearest_dollar"
     assert floor == 2.5
+
+
+def test_place_is_active_on_comeout_in_legacy_rules_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "legacy"
+    bet = Place(6, 12)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 26
+    assert result.won is True
+    assert result.remove is True
+
+
+def test_place_follows_legacy_rules_mode_if_come_out_working_policy_is_invalid():
+    table = Table()
+    table.settings["come_out_working_policy"] = "invalid"
+    bet = Place(6, 12)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 26
+    assert result.won is True
+    assert result.remove is True
+
+
+def test_place_stays_inactive_on_comeout_in_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Place(6, 10)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 0
+    assert result.remove is False
+
+
+def test_place_always_working_overrides_real_casino_mode_win():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Place(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is False
+
+
+def test_place_always_working_overrides_real_casino_mode_loss():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Place(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 4))
+
+    result = bet.get_result(table)
+
+    assert result.lost
+    assert result.won is False
+    assert result.remove is True
+
+
+def test_place_always_working_overrides_real_casino_mode_no_action():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Place(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 5))
+
+    result = bet.get_result(table)
+
+    assert result.lost is False
+    assert result.won is False
+    assert result.pushed is False
+    assert result.amount == 0
+    assert result.remove is False
+
+
+def test_buy_stays_inactive_on_comeout_in_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Buy(6, 10)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 0
+    assert result.remove is False
+
+
+def test_buy_always_working_overrides_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Buy(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is True
+
+
+def test_lay_stays_inactive_on_comeout_in_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Lay(6, 10)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 0
+    assert result.remove is False
+
+
+def test_lay_always_working_overrides_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Lay(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 4))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is True
+
+
+def test_put_stays_inactive_on_comeout_in_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Put(6, 10)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == 0
+    assert result.remove is False
+
+
+def test_put_always_working_overrides_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Put(6, 10, always_working=True)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is True
+
+
+def test_dontcome_odds_work_on_comeout_in_real_casino_mode():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Odds(DontCome, 6, 10)
+
+    table.dice.fixed_roll((3, 4))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is True
+
+
+def test_dontcome_odds_work_on_comeout_in_legacy_mode():
+    table = Table()
+    bet = Odds(DontCome, 6, 10)
+
+    table.dice.fixed_roll((3, 4))
+
+    result = bet.get_result(table)
+
+    assert result.won
+    assert result.remove is True
+
+
+@pytest.mark.parametrize(
+    "roll, expected_amount, expected_remove",
+    [
+        ((3, 3), 10, True),
+        ((3, 4), 10, True),
+        ((2, 3), 0, False),
+    ],
+)
+def test_light_side_odds_not_working_on_comeout_only_ignores_resolving_totals(
+    roll, expected_amount, expected_remove
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Odds(Come, 6, 10)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.amount == expected_amount
+    assert result.remove is expected_remove
+    if expected_remove:
+        assert result.pushed
 
 
 def test_put_odds_allowed_when_point_on():

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -708,7 +708,6 @@ def test_place_is_active_on_comeout_in_legacy_rules_mode():
     bet = Place(6, 12)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 26
@@ -722,7 +721,6 @@ def test_place_follows_real_casino_rules_mode_if_come_out_working_policy_is_inva
     bet = Place(6, 12)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -736,7 +734,6 @@ def test_place_stays_inactive_on_comeout_in_real_casino_mode():
     bet = Place(6, 10)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -757,7 +754,6 @@ def test_explicit_false_overrides_legacy_comeout_behavior(bet, roll):
     table.settings["come_out_working_policy"] = "legacy"
 
     table.dice.fixed_roll(roll)
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -771,7 +767,6 @@ def test_place_always_working_overrides_real_casino_mode_win():
     bet = Place(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.won
@@ -784,7 +779,6 @@ def test_place_always_working_overrides_real_casino_mode_loss():
     bet = Place(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 4))
-
     result = bet.get_result(table)
 
     assert result.lost
@@ -798,7 +792,6 @@ def test_place_always_working_overrides_real_casino_mode_no_action():
     bet = Place(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 5))
-
     result = bet.get_result(table)
 
     assert result.lost is False
@@ -814,7 +807,6 @@ def test_place_non_removing_win_credits_profit_only_to_bankroll():
     bet = Place(6, 6, always_working=True)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == pytest.approx(13)
@@ -828,7 +820,6 @@ def test_buy_stays_inactive_on_comeout_in_real_casino_mode():
     bet = Buy(6, 10)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -841,7 +832,6 @@ def test_buy_always_working_overrides_real_casino_mode():
     bet = Buy(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.won
@@ -854,7 +844,6 @@ def test_lay_stays_inactive_on_comeout_in_real_casino_mode():
     bet = Lay(6, 10)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -867,7 +856,6 @@ def test_lay_always_working_overrides_real_casino_mode():
     bet = Lay(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 4))
-
     result = bet.get_result(table)
 
     assert result.won
@@ -880,7 +868,6 @@ def test_put_stays_inactive_on_comeout_in_real_casino_mode():
     bet = Put(6, 10)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.amount == 0
@@ -893,7 +880,6 @@ def test_put_always_working_overrides_real_casino_mode():
     bet = Put(6, 10, always_working=True)
 
     table.dice.fixed_roll((3, 3))
-
     result = bet.get_result(table)
 
     assert result.won
@@ -906,7 +892,6 @@ def test_dontcome_odds_work_on_comeout_in_real_casino_mode():
     bet = Odds(DontCome, 6, 10)
 
     table.dice.fixed_roll((3, 4))
-
     result = bet.get_result(table)
 
     assert result.won
@@ -915,10 +900,21 @@ def test_dontcome_odds_work_on_comeout_in_real_casino_mode():
 
 def test_dontcome_odds_work_on_comeout_in_legacy_mode():
     table = Table()
+    table.settings["come_out_working_policy"] = "legacy"
     bet = Odds(DontCome, 6, 10)
 
     table.dice.fixed_roll((3, 4))
+    result = bet.get_result(table)
 
+    assert result.won
+    assert result.remove is True
+
+
+def test_dontcome_odds_work_on_comeout_by_default():
+    table = Table()
+    bet = Odds(DontCome, 6, 10)
+
+    table.dice.fixed_roll((3, 4))
     result = bet.get_result(table)
 
     assert result.won

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -814,6 +814,92 @@ def test_place_non_removing_win_credits_profit_only_to_bankroll():
     assert result.bankroll_change == pytest.approx(7)
 
 
+def test_place_point_on_win_keeps_bet_and_credits_profit_only():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.point.number = 4
+    bet = Place(6, 6)
+
+    table.dice.fixed_roll((3, 3))
+    result = bet.get_result(table)
+
+    assert result.won is True
+    assert result.remove is False
+    assert result.amount == pytest.approx(13)
+    assert result.bankroll_change == pytest.approx(7)
+
+
+def test_place_point_on_loss_removes_stake():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    table.point.number = 4
+    bet = Place(6, 12)
+
+    table.dice.fixed_roll((3, 4))
+    result = bet.get_result(table)
+
+    assert result.lost is True
+    assert result.won is False
+    assert result.remove is True
+    assert result.bankroll_change == 0
+
+
+@pytest.mark.parametrize(
+    "bet, win_roll, loss_roll",
+    [
+        (Buy(4, 10), (2, 2), (3, 4)),
+        (Lay(4, 10), (3, 4), (2, 2)),
+        (Put(6, 10), (3, 3), (3, 4)),
+    ],
+)
+def test_number_bets_point_on_win_and_loss(bet, win_roll, loss_roll):
+    """Point On Win → payout, REMOVE; Point On Loss → lose stake, REMOVE."""
+    # Win case
+    table_win = Table()
+    table_win.settings["come_out_working_policy"] = "real_casino"
+    table_win.settings["vig_paid_on_win"] = True
+    table_win.point.number = 8
+    table_win.dice.fixed_roll(win_roll)
+    win_result = bet.get_result(table_win)
+
+    assert win_result.won is True
+    assert win_result.remove is True
+    assert win_result.bankroll_change > 0
+
+    # Loss case
+    table_loss = Table()
+    table_loss.settings["come_out_working_policy"] = "real_casino"
+    table_loss.settings["vig_paid_on_win"] = True
+    table_loss.point.number = 8
+    table_loss.dice.fixed_roll(loss_roll)
+    loss_result = bet.get_result(table_loss)
+
+    assert loss_result.lost is True
+    assert loss_result.remove is True
+    assert loss_result.bankroll_change == 0
+
+
+@pytest.mark.parametrize(
+    "bet, roll",
+    [
+        (Buy(6, 10, always_working=True), (3, 4)),
+        (Lay(6, 10, always_working=True), (3, 3)),
+        (Put(6, 10, always_working=True), (3, 4)),
+    ],
+)
+def test_removing_number_bets_lose_on_comeout_when_always_working(bet, roll):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.lost is True
+    assert result.won is False
+    assert result.remove is True
+    assert result.bankroll_change == 0
+
+
 def test_buy_stays_inactive_on_comeout_in_real_casino_mode():
     table = Table()
     table.settings["come_out_working_policy"] = "real_casino"
@@ -1088,6 +1174,59 @@ def test_light_side_odds_not_working_on_comeout_only_ignores_resolving_totals(
     assert result.remove is expected_remove
     if expected_remove:
         assert result.pushed
+
+
+@pytest.mark.parametrize(
+    "roll, expected_won, expected_lost",
+    [
+        ((3, 3), True, False),
+        ((3, 4), False, True),
+    ],
+)
+def test_come_odds_always_working_resolves_on_comeout(
+    roll, expected_won, expected_lost
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Odds(Come, 6, 10, always_working=True)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.won is expected_won
+    assert result.lost is expected_lost
+    assert result.remove is True
+    if expected_won:
+        assert result.bankroll_change > bet.amount
+    else:
+        assert result.bankroll_change == 0
+
+
+@pytest.mark.parametrize(
+    "roll, expected_amount, expected_remove",
+    [
+        ((3, 3), 10, True),
+        ((3, 4), 10, True),
+        ((2, 3), 0, False),
+    ],
+)
+def test_dontcome_odds_can_be_off_on_comeout_and_push_on_triggers(
+    roll, expected_amount, expected_remove
+):
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Odds(DontCome, 6, 10, always_working=False)
+
+    table.dice.fixed_roll(roll)
+    result = bet.get_result(table)
+
+    assert result.amount == expected_amount
+    assert result.remove is expected_remove
+    if expected_remove:
+        assert result.pushed is True
+        assert result.bankroll_change == bet.amount
+    else:
+        assert result.bankroll_change == 0
 
 
 def test_put_odds_allowed_when_point_on():

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -112,7 +112,7 @@ def test_ev_oneroll(bet, ev):
         (crapssim.bet.DontCome(1), "DontCome(amount=1.0, number=None)"),
         (
             crapssim.bet.Odds(crapssim.bet.PassLine, 6, 1, False),
-            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0)",
+            "Odds(base_type=crapssim.bet.PassLine, number=6, amount=1.0, always_working=False)",
         ),
         (
             crapssim.bet.Odds(crapssim.bet.Come, 8, 1),
@@ -715,7 +715,7 @@ def test_place_is_active_on_comeout_in_legacy_rules_mode():
     assert result.remove is True
 
 
-def test_place_follows_legacy_rules_mode_if_come_out_working_policy_is_invalid():
+def test_place_follows_real_casino_rules_mode_if_come_out_working_policy_is_invalid():
     table = Table()
     table.settings["come_out_working_policy"] = "invalid"
     bet = Place(6, 12)
@@ -724,9 +724,9 @@ def test_place_follows_legacy_rules_mode_if_come_out_working_policy_is_invalid()
 
     result = bet.get_result(table)
 
-    assert result.amount == 26
-    assert result.won is True
-    assert result.remove is True
+    assert result.amount == 0
+    assert result.won is False
+    assert result.remove is False
 
 
 def test_place_stays_inactive_on_comeout_in_real_casino_mode():
@@ -942,7 +942,9 @@ def test_invalid_comeout_policy_falls_back_to_legacy_for_number_bets(bet_factory
 
     result = bet.get_result(table)
 
-    assert result.won is True
+    assert result.won is False
+    assert result.remove is False
+    assert result.amount == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_bet.py
+++ b/tests/unit/test_bet.py
@@ -742,6 +742,28 @@ def test_place_stays_inactive_on_comeout_in_real_casino_mode():
     assert result.remove is False
 
 
+@pytest.mark.parametrize(
+    "bet, roll",
+    [
+        (Place(6, 10, always_working=False), (3, 3)),
+        (Buy(6, 10, always_working=False), (3, 3)),
+        (Lay(6, 10, always_working=False), (3, 4)),
+        (Put(6, 10, always_working=False), (3, 3)),
+    ],
+)
+def test_explicit_false_overrides_legacy_comeout_behavior(bet, roll):
+    table = Table()
+    table.settings["come_out_working_policy"] = "legacy"
+
+    table.dice.fixed_roll(roll)
+
+    result = bet.get_result(table)
+
+    assert result.amount == 0
+    assert result.remove is False
+    assert result.bankroll_change == 0
+
+
 def test_place_always_working_overrides_real_casino_mode_win():
     table = Table()
     table.settings["come_out_working_policy"] = "real_casino"
@@ -783,6 +805,20 @@ def test_place_always_working_overrides_real_casino_mode_no_action():
     assert result.pushed is False
     assert result.amount == 0
     assert result.remove is False
+
+
+def test_place_non_removing_win_credits_profit_only_to_bankroll():
+    table = Table()
+    table.settings["come_out_working_policy"] = "real_casino"
+    bet = Place(6, 6, always_working=True)
+
+    table.dice.fixed_roll((3, 3))
+
+    result = bet.get_result(table)
+
+    assert result.amount == pytest.approx(13)
+    assert result.remove is False
+    assert result.bankroll_change == pytest.approx(7)
 
 
 def test_buy_stays_inactive_on_comeout_in_real_casino_mode():
@@ -886,6 +922,27 @@ def test_dontcome_odds_work_on_comeout_in_legacy_mode():
 
     assert result.won
     assert result.remove is True
+
+
+@pytest.mark.parametrize(
+    "bet_factory, roll",
+    [
+        (lambda: Place(6, 10), (3, 3)),
+        (lambda: Buy(6, 10), (3, 3)),
+        (lambda: Lay(6, 10), (3, 4)),
+        (lambda: Put(6, 10), (3, 3)),
+    ],
+)
+def test_invalid_comeout_policy_falls_back_to_legacy_for_number_bets(bet_factory, roll):
+    table = Table()
+    table.settings["come_out_working_policy"] = "invalid"
+    bet = bet_factory()
+
+    table.dice.fixed_roll(roll)
+
+    result = bet.get_result(table)
+
+    assert result.won is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_buy_lay.py
+++ b/tests/unit/test_buy_lay.py
@@ -54,7 +54,7 @@ def test_buy_upfront_vig_loss_is_principal_plus_vig():
     player = table.add_player(bankroll=100)
 
     starting_bankroll = player.bankroll
-    player.add_bet(Buy(4, 20))
+    player.add_bet(Buy(4, 20, always_working=True))
     assert player.bankroll == pytest.approx(starting_bankroll - 21)
 
     TableUpdate.roll(table, fixed_outcome=(3, 4))
@@ -69,7 +69,7 @@ def test_vig_paid_on_win_does_not_charge_at_placement():
     table.settings["vig_paid_on_win"] = True
     player = table.add_player(bankroll=100)
 
-    player.add_bet(Buy(4, 20))
+    player.add_bet(Buy(4, 20, always_working=True))
     assert player.bankroll == pytest.approx(80)
     active_bet = player.bets[0]
 
@@ -88,7 +88,7 @@ def test_vig_for_lay_is_on_win_amount():
     table.settings["vig_rounding"] = "none"
     player = table.add_player(bankroll=100)
 
-    player.add_bet(Lay(4, 40))
+    player.add_bet(Lay(4, 40, always_working=True))
     assert player.bankroll == pytest.approx(60)
     active_bet = player.bets[0]
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1,6 +1,5 @@
 import pytest
 
-from crapssim.point import Point
 from crapssim.rules import AbstractRules, ClassicRules, CraplessRules
 
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -44,6 +44,8 @@ from crapssim.strategy.examples import (
     Place682Come,
     PlaceInside,
     Risk12,
+    ThreePointDolly,
+    ThreePointMolly,
 )
 from crapssim.strategy.odds import (
     ComeOddsMultiplier,
@@ -51,6 +53,7 @@ from crapssim.strategy.odds import (
     DontPassOddsMultiplier,
     OddsAmount,
     OddsMultiplier,
+    PassLineWinMultiplier,
     WinMultiplier,
 )
 from crapssim.strategy.single_bet import (
@@ -64,6 +67,7 @@ from crapssim.strategy.single_bet import (
     BetPut,
 )
 from crapssim.strategy.tools import (
+    NullStrategy,
     RemoveByType,
     RemoveIfPointOff,
     ReplaceIfTrue,
@@ -1626,3 +1630,213 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
 def test_repr_names(strategy, strategy_name):
     # Check above visually make sense
     assert repr(strategy) == strategy_name
+
+
+def test_strategy_eq_non_strategy_returns_notimplemented(base_strategy):
+    assert base_strategy.__eq__(object()) is NotImplemented
+
+
+def test_add_if_true_eq_raises_for_non_strategy(example_bet):
+    strategy = AddIfTrue(example_bet, lambda p: True)
+    with pytest.raises(NotImplementedError):
+        _ = strategy == object()
+
+
+def test_add_if_true_eq_same_type_and_bet(example_bet):
+    left = AddIfTrue(example_bet, lambda p: True)
+    right = AddIfTrue(example_bet, lambda p: False)
+    assert left == right
+
+
+def test_add_if_point_off_repr_additional():
+    bet = MagicMock()
+    strategy = AddIfPointOff(bet)
+    assert repr(strategy) == f"AddIfPointOff(bet={bet})"
+
+
+def test_add_if_point_on_repr_additional():
+    bet = MagicMock()
+    strategy = AddIfPointOn(bet)
+    assert repr(strategy) == f"AddIfPointOn(bet={bet})"
+
+
+def test_add_if_new_shooter_repr_additional():
+    bet = MagicMock()
+    strategy = AddIfNewShooter(bet)
+    assert repr(strategy) == f"AddIfNewShooter(bet={bet})"
+
+
+def test_remove_if_true_completed_empty_bets(player):
+    strategy = RemoveIfTrue(key=lambda b, p: True)
+    player.bets = []
+    assert strategy.completed(player)
+
+
+def test_replace_if_true_key_false_branch(player):
+    strategy = ReplaceIfTrue(PassLine(10), key=lambda b, p: False)
+    player.bets = [PassLine(5)]
+    player.add_bet = MagicMock()
+    player.remove_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    player.remove_bet.assert_not_called()
+    player.add_bet.assert_not_called()
+
+
+def test_replace_if_true_completed(player):
+    strategy = ReplaceIfTrue(PassLine(5), key=lambda b, p: True)
+    player.bankroll = 4
+    player.bets = []
+    assert strategy.completed(player)
+
+
+def test_null_strategy_completed_false(player):
+    strategy = NullStrategy()
+    assert strategy.completed(player) is False
+
+
+def test_odds_amount_completed(player):
+    strategy = OddsAmount(PassLine, {4: 5})
+    assert strategy.completed(player)
+
+    player.bets = [PassLine(5)]
+    assert not strategy.completed(player)
+
+
+def test_odds_multiplier_get_point_number_invalid_bet_raises():
+    table = Table()
+    with pytest.raises(NotImplementedError):
+        OddsMultiplier.get_point_number(Field(5), table)
+
+
+def test_win_multiplier_invalid_base_type_returns_none_multiplier():
+    strategy = WinMultiplier(Field, 1)
+    assert strategy.odds_multiplier is None
+
+
+def test_base_win_multiplier_defaults_and_repr():
+    strategy = PassLineWinMultiplier()
+    assert strategy.win_multiplier == {4: 6.0, 5: 6.0, 6: 6.0, 8: 6.0, 9: 6.0, 10: 6.0}
+    assert repr(strategy) == "PassLineWinMultiplier(win_multiplier=6.0)"
+
+
+def test_hammerlock_completed(player):
+    strategy = HammerLock(5)
+    player.bankroll = 4
+    player.bets = []
+    assert strategy.completed(player)
+
+
+def test_hammerlock_update_bets_remove_place_at_two_wins(player):
+    strategy = HammerLock(5)
+    strategy.place_win_count = 2
+    player.table.point.number = 4
+    player.bets = [Place(6, 6), DontPass(5)]
+    player.remove_bet = MagicMock()
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    player.remove_bet.assert_called_once_with(Place(6, 6))
+    player.add_bet.assert_called_once_with(Odds(DontPass, 4, 30))
+
+
+def test_hammerlock_update_bets_count_over_two_skips_place_transitions(player):
+    strategy = HammerLock(5)
+    strategy.place_win_count = 3
+    strategy.place68 = MagicMock()
+    strategy.place5689 = MagicMock()
+    strategy.pass_and_dontpass = MagicMock()
+    player.table.point.number = 4
+    player.bets = [DontPass(5)]
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    strategy.place68.assert_not_called()
+    strategy.place5689.assert_not_called()
+    strategy.pass_and_dontpass.assert_not_called()
+    player.add_bet.assert_called_once_with(Odds(DontPass, 4, 30))
+
+
+def test_risk12_completed(player):
+    strategy = Risk12()
+    player.bankroll = 4
+    player.bets = []
+    assert strategy.completed(player)
+
+
+def test_risk12_point_off_insufficient_budget(player):
+    strategy = Risk12()
+    strategy.min_bankroll = player.bankroll
+    player.add_bet = MagicMock()
+
+    strategy.point_off(player)
+
+    player.add_bet.assert_not_called()
+
+
+def test_risk12_point_on_single_place_hits_else_branch(player):
+    strategy = Risk12()
+    strategy.min_bankroll = 88
+    player.bankroll = 94
+    player.table.point.number = 6
+    player.add_bet = MagicMock()
+
+    strategy.point_on(player)
+
+    player.add_bet.assert_called_once_with(Place(8, 6))
+
+
+def test_risk12_point_on_single_place_for_non_six_point(player):
+    strategy = Risk12()
+    strategy.min_bankroll = 88
+    player.bankroll = 94
+    player.table.point.number = 5
+    player.add_bet = MagicMock()
+
+    strategy.point_on(player)
+
+    player.add_bet.assert_called_once_with(Place(6, 6))
+
+
+def test_risk12_update_bets_ignores_unexpected_point_status(player):
+    strategy = Risk12()
+    strategy.point_off = MagicMock()
+    strategy.point_on = MagicMock()
+    player.table.new_shooter = False
+    player.table.point = MagicMock(status="Unknown")
+
+    strategy.update_bets(player)
+
+    strategy.point_off.assert_not_called()
+    strategy.point_on.assert_not_called()
+
+
+def test_place_68pr_completed(player):
+    strategy = Place68PR(6)
+    player.bankroll = 5
+    player.bets = []
+    assert strategy.completed(player)
+
+
+def test_three_point_molly_no_odds_branch():
+    strategy = ThreePointMolly(5, odds_multiplier=None)
+    assert len(strategy.strategies) == 2
+
+
+def test_three_point_dolly_no_odds_branch():
+    strategy = ThreePointDolly(5, win_multiplier=None)
+    assert len(strategy.strategies) == 2
+
+
+def test_win_progression_completed_and_repr(player):
+    strategy = WinProgression(PassLine(5), [1, 2, 3])
+    player.bankroll = 0
+    player.bets = []
+
+    assert strategy.completed(player)
+    assert (
+        repr(strategy) == "WinProgression(first_bet=$5 PassLine, multipliers=[1, 2, 3])"
+    )

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1,3 +1,4 @@
+import enum
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -50,7 +51,13 @@ from crapssim.strategy.odds import (
     OddsMultiplier,
     WinMultiplier,
 )
-from crapssim.strategy.single_bet import StrategyMode, _BaseSingleBet
+from crapssim.strategy.single_bet import (
+    StrategyMode,
+    _BaseSingleBet,
+    BetHardWay,
+    BetHop,
+    BetPlace,
+)
 from crapssim.strategy.tools import RemoveByType, RemoveIfPointOff, ReplaceIfTrue
 
 
@@ -721,6 +728,31 @@ def test_base_single_bet_bet_point_on_when_point_off(player):
     player.remove_bet.assert_called_once_with(Place(4, 5))
 
 
+def test_single_bet_add_if_new_shooter_mode(player):
+    strategy = _BaseSingleBet(PassLine(5), StrategyMode.ADD_IF_NEW_SHOOTER)
+    player.add_bet = MagicMock()
+
+    player.table.new_shooter = False
+    strategy.update_bets(player)
+    player.add_bet.assert_not_called()
+
+    player.table.new_shooter = True
+    strategy.update_bets(player)
+    player.add_bet.assert_called_once_with(PassLine(5))
+
+
+def test_base_single_bet_invalid_mode_is_noop(player):
+    class InvalidStrategyMode(enum.Enum):
+        INVALID = enum.auto()
+
+    strategy = _BaseSingleBet(PassLine(5), InvalidStrategyMode.INVALID)
+    player.add_bet = MagicMock()
+    player.remove_bet = MagicMock()
+    strategy.update_bets(player)
+    player.add_bet.assert_not_called()
+    player.remove_bet.assert_not_called()
+
+
 def test_bet_place_remove_point_bet(player):
     strategy = BetPlace({5: 5})
     player.bets = [Place(5, 5)]
@@ -1123,6 +1155,16 @@ def test_risk_12_point_on_10_pre_point_winnings(player):
     player.table.point.number = 5
     strategy.point_on(player)
     player.add_bet.assert_has_calls([call(Place(6, 6)), call(Place(8, 6))])
+
+
+def test_bethardway_rejects_invalid_number():
+    with pytest.raises(NotImplementedError):
+        BetHardWay(5, bet_amount=5)
+
+
+def test_bethop_rejects_invalid_result():
+    with pytest.raises(NotImplementedError):
+        BetHop((1, 7), bet_amount=1)
 
 
 def test_dice_doctor_win_increase_progression(player):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -63,7 +63,12 @@ from crapssim.strategy.single_bet import (
     BetPlace,
     BetPut,
 )
-from crapssim.strategy.tools import RemoveByType, RemoveIfPointOff, ReplaceIfTrue
+from crapssim.strategy.tools import (
+    RemoveByType,
+    RemoveIfPointOff,
+    ReplaceIfTrue,
+    WinProgression,
+)
 
 
 @pytest.fixture
@@ -1326,12 +1331,33 @@ def test_place_68_cpr_press_no_increases(player):
     player.add_bet.assert_not_called()
 
 
+def test_place_68_cpr_regress_after_second_win(player):
+    strategy = Place68PR(6)
+    player.bets = [Place(6, 12), Place(8, 6)]
+    strategy.six_winnings = 14
+
+    strategy.update_bets(player)
+
+    assert Place(6, 6) in player.bets
+    assert Place(6, 12) not in player.bets
+
+
 def test_place_68_cpr_update_bets_initial_bets(player):
     strategy = Place68PR(6)
     player.add_bet = MagicMock()
     player.table.point.number = 6
     strategy.update_bets(player)
     player.add_bet.assert_has_calls([call(Place(6, 6)), call(Place(8, 6))])
+
+
+def test_win_progression_replaces_existing_progression_bet(player):
+    strategy = WinProgression(Place(6, 12), [1, 2, 3])
+    strategy.current_progression = 1
+    player.bets = [Place(6, 12)]
+
+    strategy.update_bets(player)
+
+    assert player.bets == [Place(6, 24)]
 
 
 def test_place_68_cpr_update_bets_initial_bets_placed_push_6_add_bet(player):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -10,11 +10,13 @@ from crapssim import Player, Table
 from crapssim.bet import (
     Bet,
     BetResult,
+    Buy,
     Come,
     DontCome,
     DontPass,
     Field,
     HardWay,
+    Lay,
     Odds,
     PassLine,
     Place,
@@ -56,7 +58,10 @@ from crapssim.strategy.single_bet import (
     _BaseSingleBet,
     BetHardWay,
     BetHop,
+    BetBuy,
+    BetLay,
     BetPlace,
+    BetPut,
 )
 from crapssim.strategy.tools import RemoveByType, RemoveIfPointOff, ReplaceIfTrue
 
@@ -791,6 +796,45 @@ def test_bet_place_add_bet_not_skip_point(player):
     player.table.point.number = 5
     strategy.update_bets(player)
     player.add_bet.assert_called_once_with(Place(5, 5))
+
+
+def test_bet_place_skip_come_ignores_untraveled_come_bets(player):
+    strategy = BetPlace({5: 10, 6: 12}, skip_point=False, skip_come=True)
+    player.table.point.number = 4
+    player.bets = [Come(10)]
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    assert player.add_bet.call_args_list == [call(Place(5, 10)), call(Place(6, 12))]
+
+
+def test_betbuy_preserves_always_working_argument(player):
+    strategy = BetBuy(6, 10, always_working=True)
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    player.add_bet.assert_called_once_with(Buy(6, 10, always_working=True))
+
+
+def test_betlay_preserves_always_working_argument(player):
+    strategy = BetLay(6, 10, always_working=True)
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    player.add_bet.assert_called_once_with(Lay(6, 10, always_working=True))
+
+
+def test_betput_preserves_always_working_argument(player):
+    strategy = BetPut(6, 10, always_working=True)
+    player.table.point.number = 4
+    player.add_bet = MagicMock()
+
+    strategy.update_bets(player)
+
+    player.add_bet.assert_called_once_with(Put(6, 10, always_working=True))
 
 
 def test_pass_2_come_point_off_passline(player):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -523,6 +523,17 @@ def test_remove_if_point_off_remove_bet(player):
     player.remove_bet.assert_not_called()
 
 
+def test_remove_if_point_off_place_removes_only_matching_number(player):
+    player.table.point.number = None
+    player.bets = [Place(6, 6), Place(8, 6)]
+
+    strategy = RemoveIfPointOff(Place(6, 6))
+    strategy.update_bets(player)
+
+    assert Place(6, 6) not in player.bets
+    assert Place(8, 6) in player.bets
+
+
 def test_remove_by_type_remove_bet_called(player):
     strategy = RemoveByType(PassLine)
     player.remove_bet = MagicMock()
@@ -1364,6 +1375,15 @@ def test_win_progression_replaces_existing_progression_bet(player):
     assert player.bets == [Place(6, 24)]
 
 
+def test_win_progression_does_not_mutate_input_bet_instance():
+    first_bet = Place(6, 12)
+    assert first_bet.always_working is None
+
+    WinProgression(first_bet, [1, 2, 3])
+
+    assert first_bet.always_working is None
+
+
 def test_place_68_cpr_update_bets_initial_bets_placed_push_6_add_bet(player):
     strategy = Place68PR(6)
     player.add_bet = MagicMock()
@@ -1511,7 +1531,7 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
             crapssim.strategy.odds.OddsAmount(
                 PassLine, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
             ),
-            "OddsAmount(base_type=crapssim.bet.PassLine, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+            "OddsAmount(base_type=crapssim.bet.PassLine, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10}, always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsAmount(
@@ -1523,13 +1543,13 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
             crapssim.strategy.odds.OddsAmount(
                 Come, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
             ),
-            "OddsAmount(base_type=crapssim.bet.Come, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+            "OddsAmount(base_type=crapssim.bet.Come, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10}, always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsAmount(
                 DontPass, {x: 10 for x in (4, 5, 6, 8, 9, 10)}
             ),
-            "OddsAmount(base_type=crapssim.bet.DontPass, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10})",
+            "OddsAmount(base_type=crapssim.bet.DontPass, odds_amounts={4: 10, 5: 10, 6: 10, 8: 10, 9: 10, 10: 10}, always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsAmount(
@@ -1539,7 +1559,7 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         ),
         (
             crapssim.strategy.odds.PassLineOddsAmount(10),
-            "PassLineOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+            "PassLineOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=False)",
         ),
         (
             crapssim.strategy.odds.PassLineOddsAmount(10, always_working=True),
@@ -1551,23 +1571,23 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         ),
         (
             crapssim.strategy.odds.ComeOddsAmount(10),
-            "ComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+            "ComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=False)",
         ),
         (
             crapssim.strategy.odds.DontPassOddsAmount(10),
-            "DontPassOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+            "DontPassOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=False)",
         ),
         (
             crapssim.strategy.odds.DontComeOddsAmount(10),
-            "DontComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10))",
+            "DontComeOddsAmount(bet_amount=10.0, numbers=(4, 5, 6, 8, 9, 10), always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsMultiplier(PassLine, 2.0, False),
-            "OddsMultiplier(base_type=crapssim.bet.PassLine, odds_multiplier=2.0)",
+            "OddsMultiplier(base_type=crapssim.bet.PassLine, odds_multiplier=2.0, always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsMultiplier(PassLine, 2.0, False),
-            "OddsMultiplier(base_type=crapssim.bet.PassLine, odds_multiplier=2.0)",
+            "OddsMultiplier(base_type=crapssim.bet.PassLine, odds_multiplier=2.0, always_working=False)",
         ),
         (
             crapssim.strategy.odds.OddsMultiplier(PassLine, 2, True),
@@ -1575,15 +1595,15 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         ),
         (
             crapssim.strategy.odds.OddsMultiplier(DontPass, 1.0, False),
-            "OddsMultiplier(base_type=crapssim.bet.DontPass, odds_multiplier=1.0)",
+            "OddsMultiplier(base_type=crapssim.bet.DontPass, odds_multiplier=1.0, always_working=False)",
         ),
         (
             crapssim.strategy.odds.PassLineOddsMultiplier(),
-            "PassLineOddsMultiplier(odds_multiplier={4: 3.0, 5: 4.0, 6: 5.0, 8: 5.0, 9: 4.0, 10: 3.0})",
+            "PassLineOddsMultiplier(odds_multiplier={4: 3.0, 5: 4.0, 6: 5.0, 8: 5.0, 9: 4.0, 10: 3.0}, always_working=False)",
         ),
         (
             crapssim.strategy.odds.PassLineOddsMultiplier(2),
-            "PassLineOddsMultiplier(odds_multiplier=2)",
+            "PassLineOddsMultiplier(odds_multiplier=2, always_working=False)",
         ),
         (
             crapssim.strategy.odds.PassLineOddsMultiplier(2, always_working=True),
@@ -1595,7 +1615,7 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         ),
         (
             crapssim.strategy.odds.DontPassOddsMultiplier(2),
-            "DontPassOddsMultiplier(odds_multiplier=2)",
+            "DontPassOddsMultiplier(odds_multiplier=2, always_working=False)",
         ),
         (
             crapssim.strategy.odds.DontComeOddsMultiplier(2, always_working=True),
@@ -1603,27 +1623,27 @@ def test_place_68_cpr_update_bets_initial_bets_placed_no_update(player):
         ),
         (
             crapssim.strategy.odds.WinMultiplier(DontPass, 2),
-            "WinMultiplier(base_type=crapssim.bet.DontPass, win_multiplier=2)",
+            "WinMultiplier(base_type=crapssim.bet.DontPass, win_multiplier=2, always_working=False)",
         ),
         (
             crapssim.strategy.odds.WinMultiplier(PassLine, 1),
-            "WinMultiplier(base_type=crapssim.bet.PassLine, win_multiplier=1)",
+            "WinMultiplier(base_type=crapssim.bet.PassLine, win_multiplier=1, always_working=False)",
         ),
         (
             crapssim.strategy.odds.WinMultiplier(
                 Come, {4: 2, 5: 1, 6: 1, 8: 1, 9: 1, 10: 2}
             ),
-            "WinMultiplier(base_type=crapssim.bet.Come, win_multiplier={4: 2, 5: 1, 6: 1, 8: 1, 9: 1, 10: 2})",
+            "WinMultiplier(base_type=crapssim.bet.Come, win_multiplier={4: 2, 5: 1, 6: 1, 8: 1, 9: 1, 10: 2}, always_working=False)",
         ),
         (
             crapssim.strategy.odds.WinMultiplier(
                 PassLine, {x: 6 for x in (4, 5, 6, 8, 9, 10)}
             ),
-            "WinMultiplier(base_type=crapssim.bet.PassLine, win_multiplier=6)",
+            "WinMultiplier(base_type=crapssim.bet.PassLine, win_multiplier=6, always_working=False)",
         ),
         (
             crapssim.strategy.odds.WinMultiplier(DontCome, {6: 2}),
-            "WinMultiplier(base_type=crapssim.bet.DontCome, win_multiplier={6: 2})",
+            "WinMultiplier(base_type=crapssim.bet.DontCome, win_multiplier={6: 2}, always_working=False)",
         ),
     ],
 )
@@ -1718,7 +1738,10 @@ def test_win_multiplier_invalid_base_type_returns_none_multiplier():
 def test_base_win_multiplier_defaults_and_repr():
     strategy = PassLineWinMultiplier()
     assert strategy.win_multiplier == {4: 6.0, 5: 6.0, 6: 6.0, 8: 6.0, 9: 6.0, 10: 6.0}
-    assert repr(strategy) == "PassLineWinMultiplier(win_multiplier=6.0)"
+    assert (
+        repr(strategy)
+        == "PassLineWinMultiplier(win_multiplier=6.0, always_working=False)"
+    )
 
 
 def test_hammerlock_completed(player):


### PR DESCRIPTION
# Summary

This PR fixes the handling of working bets during the come-out roll and adds comprehensive regression tests to prevent future regressions. It also introduces a configurable table policy so different casino behaviors can be modeled without changing bet implementations.

# Issue

Addresses Issue https://github.com/skent259/crapssim/issues/80

# Changes

### Come-out working policy

- Add configurable `come_out_working_policy` to `TableSettings`
- Support `legacy` and `real_casino` behavior

### Bet behavior

- Refactor come-out working logic into a centralized policy
- Change `always_working` from a boolean to a tri-state (`None`, `True`, `False`) so bets can either:
  - inherit the table policy,
  - always work, or
  - never work
- Update affected bet implementations to use the new behavior

### Strategy fixes

#### `strategy/examples.py`

Updated the `Place68PR` regression logic to improve progression behavior after the initial press sequence.
- Refine the regression implementation to correctly restore the intended base betting state.
- Ensure subsequent presses and collections continue from the proper post-regression amounts.
- Improve consistency with the documented strategy behavior and expected progression.

#### `strategy/tools.py`

Refactor `AddIfNewShooter` to improve handling of new shooters and existing bets.

- Prevent duplicate bets from being added when the strategy is triggered multiple times for the same shooter.
- Ensure new bets are only added at the start of a new shooter, even if matching bets already exist on the table.
- Improve compatibility with progression and regression strategies that modify or replace bets during a shooter's hand.
- Add regression tests covering repeated triggers and new shooter transitions to prevent future regressions.


# Tests

- Add regression tests covering:
  - Place bets
  - Buy bets
  - Lay bets
  - Put bets
  - Come bets
  - Don't Come bets
  - Odds bets
  - Crapless interactions
- Increase overall project test coverage to **100%**

## Test Results

| Metric | Value |
|--------|------:|
| Passed | **4,283** |
| Skipped | **1** |
| Failed | **0** |
| Total Tests | **4,284** |
| Overall Statement Coverage | **100%** |
| Python Version | **3.14.6** |
| Platform | **macOS (darwin)** |

## Test Coverage

| File | Stmts | Miss | Branch | BrPart | Cover |
|------|------:|-----:|-------:|--------:|------:|
| `crapssim/__init__.py` | 4 | 0 | 0 | 0 | **100%** |
| `crapssim/bet.py` | 743 | 0 | 166 | 0 | **100%** |
| `crapssim/dice.py` | 32 | 0 | 4 | 0 | **100%** |
| `crapssim/point.py` | 59 | 0 | 36 | 0 | **100%** |
| `crapssim/rules.py` | 42 | 0 | 2 | 0 | **100%** |
| `crapssim/strategy/__init__.py` | 4 | 0 | 0 | 0 | **100%** |
| `crapssim/strategy/examples.py` | 283 | 0 | 68 | 0 | **100%** |
| `crapssim/strategy/odds.py` | 135 | 0 | 24 | 0 | **100%** |
| `crapssim/strategy/single_bet.py` | 149 | 0 | 32 | 0 | **100%** |
| `crapssim/strategy/tools.py` | 219 | 0 | 62 | 0 | **100%** |
| `crapssim/table.py` | 190 | 0 | 66 | 0 | **100%** |
| **TOTAL** | **1860** | **0** | **460** | **0** | **100%** |

## Final Coverage Details

| Matrix row | Status | Tests |
|---|---|---|
| **Place** | | |
| Point Off + OFF + Trigger → no action, KEEP | ✅ | `test_place_stays_inactive_on_comeout_in_real_casino_mode`, `test_come_out_policy_changes_place_buy_lay_resolution` |
| Point Off + WORKING + Win → profit, KEEP | ✅ | `test_place_always_working_overrides_real_casino_mode_win`, `test_place_non_removing_win_credits_profit_only_to_bankroll` |
| Point Off + WORKING + Loss → remove | ✅ | `test_place_always_working_overrides_real_casino_mode_loss` |
| Point On + Win → profit, KEEP | ✅ | `test_place_point_on_win_keeps_bet_and_credits_profit_only` |
| Point On + Loss → remove | ✅ | `test_place_point_on_loss_removes_stake` |
| **Buy** | | |
| Point Off + OFF + Trigger | ✅ | `test_buy_stays_inactive_on_comeout_in_real_casino_mode` |
| Point Off + WORKING + Win (vig) | ✅ | `test_buy_always_working_overrides_real_casino_mode`, `test_vig_paid_on_win_does_not_charge_at_placement` |
| Point Off + WORKING + Loss | ✅ | `test_removing_number_bets_lose_on_comeout_when_always_working`, `test_buy_upfront_vig_loss_is_principal_plus_vig` |
| Point On + Win | ✅ | `test_number_bets_point_on_win_and_loss[Buy]` |
| Point On + Loss | ✅ | `test_number_bets_point_on_win_and_loss[Buy]` |
| **Lay** | | |
| Point Off + OFF + Trigger | ✅ | `test_lay_stays_inactive_on_comeout_in_real_casino_mode` |
| Point Off + WORKING + Win (vig) | ✅ | `test_lay_always_working_overrides_real_casino_mode`, `test_vig_for_lay_is_on_win_amount` |
| Point Off + WORKING + Loss | ✅ | `test_removing_number_bets_lose_on_comeout_when_always_working` |
| Point On + Win | ✅ | `test_number_bets_point_on_win_and_loss[Lay]` |
| Point On + Loss | ✅ | `test_number_bets_point_on_win_and_loss[Lay]` |
| **Put** | | |
| Point Off + OFF + Trigger | ✅ | `test_put_stays_inactive_on_comeout_in_real_casino_mode` |
| Point Off + WORKING + Win | ✅ | `test_put_always_working_overrides_real_casino_mode` |
| Point Off + WORKING + Loss | ✅ | `test_removing_number_bets_lose_on_comeout_when_always_working` |
| Point On + Win | ✅ | `test_number_bets_point_on_win_and_loss[Put]` |
| Point On + Loss | ✅ | `test_number_bets_point_on_win_and_loss[Put]` |
| **Contract bets & odds** | | |
| Come traveled WORKING | ✅ | `test_real_casino_policy_keeps_put_inactive_but_keeps_traveled_come_working`, `test_betcome_contract_bet_stays_working_on_comeout` |
| DontCome traveled WORKING | ✅ | `test_real_casino_policy_keeps_traveled_dontcome_working_on_come_out_classic`, `test_betdontcome_contract_bet_stays_working_on_comeout` |
| Come Odds OFF by default + push on trigger | ✅ | `test_light_side_odds_not_working_on_comeout_only_ignores_resolving_totals` |
| Come Odds `always_working=True` resolves | ✅ | `test_come_odds_always_working_resolves_on_comeout` |
| DC Odds WORKING by default | ✅ | `test_dontcome_odds_work_on_comeout_by_default` + two policy variants |
| DC Odds OFF (`always_working=False`) + push on trigger | ✅ | `test_dontcome_odds_can_be_off_on_comeout_and_push_on_triggers`, `test_dontcome_odds_always_working_false_pushes_on_comeout_triggers` |
| **Bankroll accounting** | | |
| KEEP → profit only | ✅ | `test_place_non_removing_win_credits_profit_only_to_bankroll`, `test_place_point_on_win_keeps_bet_and_credits_profit_only` |
| REMOVE → principal + payout | ✅ | implicit in all vig tests and bankroll checks |
| Loss → no credit | ✅ | `bankroll_change == 0` in every loss test |
| OFF odds push → stake returned | ✅ | `test_dontcome_odds_can_be_off_on_comeout_and_push_on_triggers` |